### PR TITLE
Refactor initialization and fix bugs in init command

### DIFF
--- a/cmd/commands/init.go
+++ b/cmd/commands/init.go
@@ -19,18 +19,7 @@ import (
 )
 
 var (
-	beatozChainID = "mainnet"
-	holderCnt     = 10
-	privValCnt    = 1
-
-	blockGasLimit        = int64(36_000_000)
-	assumedBlockInterval = "7s"
-	inflationCycleBlocks = int64(86_400)
-	maxTotalSupply       = int64(700_000_000) // => 700_000_000 * 10^18
-	initTotalSupply      = int64(350_000_000)
-	initVotingPower      = int64(30_000_000)
-
-	privValSecretFeederAddr string
+	initParams = DefaultIniParams()
 )
 
 // NewRunNodeCmd returns the command that allows the CLI to start a node.
@@ -48,14 +37,14 @@ func NewInitFilesCmd() *cobra.Command {
 func AddInitFlags(cmd *cobra.Command) {
 	// bind flags
 	cmd.Flags().StringVar(
-		&beatozChainID,
+		&initParams.ChainID,
 		"chain_id",
-		beatozChainID, // default name
+		initParams.ChainID, // default name
 		"the id of chain to generate (e.g. mainnet, testnet, devnet and others)")
 	cmd.Flags().IntVar(
-		&holderCnt,
+		&initParams.HolderCnt,
 		"holders",
-		holderCnt, // default value is 10
+		initParams.HolderCnt, // default value is 10
 		"the number of holder's account files to be generated.\n"+
 			"if you create a new genesis of your own blockchain, "+
 			"you need to generate accounts of genesis holders and "+
@@ -63,9 +52,9 @@ func AddInitFlags(cmd *cobra.Command) {
 			"if `--chain_id` is `mainnet`, the holder's accounts is not generated.",
 	)
 	cmd.Flags().IntVar(
-		&privValCnt,
+		&initParams.ValCnt,
 		"priv_validator_cnt",
-		privValCnt, // default value is 1
+		initParams.ValCnt, // default value is 1
 		"the number of validators on BEATOZ network created.\n"+
 			"if you create a new genesis of your own blockchain, "+
 			"you need to generate validator's accounts and\n"+
@@ -73,44 +62,44 @@ func AddInitFlags(cmd *cobra.Command) {
 			"if there is more than one validator, the rest will be created in the $BEATOZHOME/walkeys/vals directory.",
 	)
 	cmd.Flags().Int64Var(
-		&blockGasLimit,
+		&initParams.BlockGasLimit,
 		"block_gas_limit",
-		blockGasLimit,
+		initParams.BlockGasLimit,
 		"the maximum gas that can be used in one block.\n"+
 			"this value is deterministically adjusted based on the gas usage in the blockchain network.\n"+
 			"however, it cannot exceed the `maxBlockGas` of Governance Parameters.",
 	)
 	cmd.Flags().StringVar(
-		&assumedBlockInterval,
+		&initParams.AssumedBlockInterval,
 		"assumed_block_interval",
-		assumedBlockInterval,
+		initParams.AssumedBlockInterval,
 		"assumed time between blocks in seconds, used for estimating time from block count.\n"+
 			"It is not based on actual block production timing.\n"+
 			"Instead, it is used as a constant reference to estimate time from the number of blocks produced.")
 	cmd.Flags().Int64Var(
-		&inflationCycleBlocks,
+		&initParams.InflationCycleBlocks,
 		"inflation_cycle_blocks",
-		inflationCycleBlocks,
+		initParams.InflationCycleBlocks,
 		"the number of blocks required to trigger a new inflation event.\n"+
 			"This determines the frequency of inflation based on block count, not real time.",
 	)
 	cmd.Flags().Int64Var(
-		&maxTotalSupply,
+		&initParams.MaxTotalSupply,
 		"max_total_supply",
-		maxTotalSupply,
+		initParams.MaxTotalSupply,
 		"upper limit of total supply; "+
 			"total supply will never exceed this value.",
 	)
 	cmd.Flags().Int64Var(
-		&initTotalSupply,
+		&initParams.InitTotalSupply,
 		"init_total_supply",
-		initTotalSupply,
-		"initial total supply at genesis, shared equally by all holders",
+		initParams.InitTotalSupply,
+		"initial total supply at genesis, shared equally by all holders; it includes the initial voting power",
 	)
 	cmd.Flags().Int64Var(
-		&initVotingPower,
+		&initParams.InitVotingPower,
 		"init_voting_power",
-		initVotingPower,
+		initParams.InitVotingPower,
 		"initial voting power at genesis, shared equally by all validators",
 	)
 }
@@ -137,17 +126,16 @@ func initFiles(cmd *cobra.Command, args []string) error {
 		libs.ClearCredential(s1)
 	}()
 
-	return InitFilesWith(beatozChainID, rootConfig, privValCnt, s0, holderCnt, s1)
+	initParams.ValSecret = s0
+	initParams.HolderSecret = s1
+
+	return InitFilesWith(rootConfig, initParams)
 }
 
-func InitFilesWith(chainID string, config *cfg.Config, vcnt int, vsecret []byte, hcnt int, hsecret []byte) error {
-	if initTotalSupply > maxTotalSupply {
-		return fmt.Errorf("init_total_supply (%d) cannot exceed max_total_supply (%d)", initTotalSupply, maxTotalSupply)
+func InitFilesWith(config *cfg.Config, params *InitParams) error {
+	if err := params.Validate(); err != nil {
+		return err
 	}
-	if initVotingPower > initTotalSupply {
-		return fmt.Errorf("init_voting_power (%d) cannot exceed init_total_supply (%d)", initVotingPower, initTotalSupply)
-	}
-
 	// private validator
 	privValKeyFile := config.PrivValidatorKeyFile()
 	privValStateFile := config.PrivValidatorStateFile()
@@ -159,20 +147,20 @@ func InitFilesWith(chainID string, config *cfg.Config, vcnt int, vsecret []byte,
 	}
 
 	var pvs []*acrypto.SFilePV
-	for i := 0; i < vcnt; i++ {
+	for i := 0; i < params.ValCnt; i++ {
 		var pv *acrypto.SFilePV
 
 		_keyFilePath := fmt.Sprintf("%s/%s%d%s", defaultValDirPath, strings.TrimSuffix(filepath.Base(privValKeyFile), filepath.Ext(privValKeyFile)), i, filepath.Ext(privValKeyFile))
 		_keyStateFilePath := fmt.Sprintf("%s/%s%d%s", defaultValDirPath, strings.TrimSuffix(filepath.Base(privValStateFile), filepath.Ext(privValStateFile)), i, filepath.Ext(_keyFilePath))
 
 		if tmos.FileExists(_keyFilePath) {
-			pv = acrypto.LoadSFilePV(_keyFilePath, _keyStateFilePath, vsecret)
+			pv = acrypto.LoadSFilePV(_keyFilePath, _keyStateFilePath, params.ValSecret)
 			logger.Info("Found private validator", "keyFile", _keyFilePath,
 				"stateFile", _keyStateFilePath)
 			//pv.SaveWith(secret) // encrypt with new driven key.
 		} else {
 			pv = acrypto.GenSFilePV(_keyFilePath, _keyStateFilePath)
-			pv.SaveWith(vsecret)
+			pv.SaveWith(params.ValSecret)
 			logger.Info("Generated private validator", "keyFile", _keyFilePath,
 				"stateFile", _keyStateFilePath)
 		}
@@ -209,12 +197,12 @@ func InitFilesWith(chainID string, config *cfg.Config, vcnt int, vsecret []byte,
 	} else {
 		var err error
 		var genDoc *tmtypes.GenesisDoc
-		if chainID == "mainnet" {
-			if genDoc, err = genesis.MainnetGenesisDoc(chainID); err != nil {
+		if params.ChainID == "mainnet" {
+			if genDoc, err = genesis.MainnetGenesisDoc(params.ChainID); err != nil {
 				return err
 			}
-		} else if chainID == "testnet" {
-			if genDoc, err = genesis.TestnetGenesisDoc(chainID); err != nil {
+		} else if params.ChainID == "testnet" {
+			if genDoc, err = genesis.TestnetGenesisDoc(params.ChainID); err != nil {
 				return err
 			}
 		} else { // anything (e.g. loclanet)
@@ -225,8 +213,8 @@ func InitFilesWith(chainID string, config *cfg.Config, vcnt int, vsecret []byte,
 			}
 			//
 			// Initialize validators at genesis
-			pow := initVotingPower / int64(len(pvs))
-			rpow := initVotingPower % int64(len(pvs))
+			pow := params.InitVotingPower / int64(len(pvs))
+			rpow := params.InitVotingPower % int64(len(pvs))
 			var valset []tmtypes.GenesisValidator
 			for i, pv := range pvs {
 				if i == len(pvs)-1 {
@@ -246,14 +234,15 @@ func InitFilesWith(chainID string, config *cfg.Config, vcnt int, vsecret []byte,
 
 			//
 			// Initialize asset holders at genesis
-			walkeys, err := acrypto.CreateWalletKeyFiles(hsecret, hcnt, defaultWalkeyDirPath)
+			walkeys, err := acrypto.CreateWalletKeyFiles(params.HolderSecret, params.HolderCnt, defaultWalkeyDirPath)
 			if err != nil {
 				return err
 			}
 			logger.Info("Generated initial holder's wallet key files", "path", defaultWalkeyDirPath)
 
-			amt := initTotalSupply / int64(len(walkeys))
-			ramt := initTotalSupply % int64(len(walkeys))
+			realInitSupply := params.InitTotalSupply - params.InitVotingPower
+			amt := realInitSupply / int64(len(walkeys))
+			ramt := realInitSupply % int64(len(walkeys))
 			holders := make([]*genesis.GenesisAssetHolder, len(walkeys))
 			for i, wk := range walkeys {
 				if i == len(walkeys)-1 {
@@ -268,19 +257,19 @@ func InitFilesWith(chainID string, config *cfg.Config, vcnt int, vsecret []byte,
 
 			//
 			// Create Governance Parameters at genesis
-			blockInterval, err := time.ParseDuration(assumedBlockInterval)
+			blockInterval, err := time.ParseDuration(params.AssumedBlockInterval)
 			if err != nil {
 				return err
 			}
 			govParams := types.NewGovParams(int(blockInterval.Seconds()))
-			govParams.GetValues().InflationCycleBlocks = inflationCycleBlocks
-			govParams.GetValues().XMaxTotalSupply = btztypes.ToFons(uint64(maxTotalSupply)).Bytes()
+			govParams.GetValues().InflationCycleBlocks = params.InflationCycleBlocks
+			govParams.GetValues().XMaxTotalSupply = btztypes.ToFons(uint64(params.MaxTotalSupply)).Bytes()
 
-			genDoc, err = genesis.NewGenesisDoc(chainID, valset, holders, govParams)
+			genDoc, err = genesis.NewGenesisDoc(params.ChainID, valset, holders, govParams)
 			if err != nil {
 				return err
 			}
-			genDoc.ConsensusParams.Block.MaxGas = blockGasLimit
+			genDoc.ConsensusParams.Block.MaxGas = params.BlockGasLimit
 		}
 		if err := genDoc.SaveAs(genFile); err != nil {
 			return err
@@ -288,5 +277,43 @@ func InitFilesWith(chainID string, config *cfg.Config, vcnt int, vsecret []byte,
 		logger.Info("Generated genesis file", "path", genFile)
 	}
 
+	return nil
+}
+
+type InitParams struct {
+	ChainID              string
+	ValCnt               int
+	ValSecret            []byte
+	HolderCnt            int
+	HolderSecret         []byte
+	BlockGasLimit        int64
+	AssumedBlockInterval string
+	InflationCycleBlocks int64
+	MaxTotalSupply       int64
+	InitTotalSupply      int64
+	InitVotingPower      int64
+}
+
+func DefaultIniParams() *InitParams {
+	return &InitParams{
+		ChainID:              "mainnet",
+		ValCnt:               1,
+		HolderCnt:            10,
+		BlockGasLimit:        int64(36_000_000),
+		AssumedBlockInterval: "7s",
+		InflationCycleBlocks: int64(86_400),
+		MaxTotalSupply:       int64(700_000_000),
+		InitTotalSupply:      int64(350_000_000),
+		InitVotingPower:      int64(35_000_000),
+	}
+}
+
+func (params *InitParams) Validate() error {
+	if params.InitTotalSupply > params.MaxTotalSupply {
+		return fmt.Errorf("init_total_supply (%d) cannot exceed max_total_supply (%d)", params.InitTotalSupply, params.MaxTotalSupply)
+	}
+	if params.InitVotingPower > params.InitTotalSupply {
+		return fmt.Errorf("init_voting_power (%d) cannot exceed init_total_supply (%d)", params.InitVotingPower, params.InitTotalSupply)
+	}
 	return nil
 }

--- a/cmd/commands/init.go
+++ b/cmd/commands/init.go
@@ -6,8 +6,8 @@ import (
 	"github.com/beatoz/beatoz-go/ctrlers/types"
 	"github.com/beatoz/beatoz-go/genesis"
 	"github.com/beatoz/beatoz-go/libs"
+	btztypes "github.com/beatoz/beatoz-go/types"
 	acrypto "github.com/beatoz/beatoz-go/types/crypto"
-	"github.com/holiman/uint256"
 	"github.com/spf13/cobra"
 	tmos "github.com/tendermint/tendermint/libs/os"
 	"github.com/tendermint/tendermint/p2p"
@@ -19,12 +19,16 @@ import (
 )
 
 var (
-	beatozChainID        = "mainnet"
-	holderCnt            = 10
-	privValCnt           = 1
+	beatozChainID = "mainnet"
+	holderCnt     = 10
+	privValCnt    = 1
+
 	blockGasLimit        = int64(36_000_000)
 	assumedBlockInterval = "7s"
-	inflationCycleBlocks = int64(86400)
+	inflationCycleBlocks = int64(86_400)
+	maxTotalSupply       = int64(700_000_000) // => 700_000_000 * 10^18
+	initTotalSupply      = int64(350_000_000)
+	initVotingPower      = int64(30_000_000)
 
 	privValSecretFeederAddr string
 )
@@ -90,6 +94,25 @@ func AddInitFlags(cmd *cobra.Command) {
 		"the number of blocks required to trigger a new inflation event.\n"+
 			"This determines the frequency of inflation based on block count, not real time.",
 	)
+	cmd.Flags().Int64Var(
+		&maxTotalSupply,
+		"max_total_supply",
+		maxTotalSupply,
+		"upper limit of total supply; "+
+			"total supply will never exceed this value.",
+	)
+	cmd.Flags().Int64Var(
+		&initTotalSupply,
+		"init_total_supply",
+		initTotalSupply,
+		"initial total supply at genesis, shared equally by all holders",
+	)
+	cmd.Flags().Int64Var(
+		&initVotingPower,
+		"init_voting_power",
+		initVotingPower,
+		"initial voting power at genesis, shared equally by all validators",
+	)
 }
 
 func initFiles(cmd *cobra.Command, args []string) error {
@@ -118,6 +141,13 @@ func initFiles(cmd *cobra.Command, args []string) error {
 }
 
 func InitFilesWith(chainID string, config *cfg.Config, vcnt int, vsecret []byte, hcnt int, hsecret []byte) error {
+	if initTotalSupply > maxTotalSupply {
+		return fmt.Errorf("init_total_supply (%d) cannot exceed max_total_supply (%d)", initTotalSupply, maxTotalSupply)
+	}
+	if initVotingPower > initTotalSupply {
+		return fmt.Errorf("init_voting_power (%d) cannot exceed init_total_supply (%d)", initVotingPower, initTotalSupply)
+	}
+
 	// private validator
 	privValKeyFile := config.PrivValidatorKeyFile()
 	privValStateFile := config.PrivValidatorStateFile()
@@ -188,21 +218,20 @@ func InitFilesWith(chainID string, config *cfg.Config, vcnt int, vsecret []byte,
 				return err
 			}
 		} else { // anything (e.g. loclanet)
+
 			defaultWalkeyDirPath := filepath.Join(config.RootDir, acrypto.DefaultWalletKeyDir)
-			err := tmos.EnsureDir(defaultWalkeyDirPath, acrypto.DefaultWalletKeyDirPerm)
-			if err != nil {
+			if err = tmos.EnsureDir(defaultWalkeyDirPath, acrypto.DefaultWalletKeyDirPerm); err != nil {
 				return err
 			}
-
-			walkeys, err := acrypto.CreateWalletKeyFiles(hsecret, hcnt, defaultWalkeyDirPath)
-			if err != nil {
-				return err
-			}
-			logger.Info("Generated initial holder's wallet key files", "path", defaultWalkeyDirPath)
-
-			pow := types.DefaultGovParams().MinValidatorPower()
+			//
+			// Initialize validators at genesis
+			pow := initVotingPower / int64(len(pvs))
+			rpow := initVotingPower % int64(len(pvs))
 			var valset []tmtypes.GenesisValidator
-			for _, pv := range pvs {
+			for i, pv := range pvs {
+				if i == len(pvs)-1 {
+					pow += rpow
+				}
 				pubKey, err := pv.GetPubKey()
 				if err != nil {
 					return fmt.Errorf("can't get pubkey: %w", err)
@@ -215,21 +244,37 @@ func InitFilesWith(chainID string, config *cfg.Config, vcnt int, vsecret []byte,
 				logger.Info("GenesisValidator", "address", pubKey.Address(), "power", pow)
 			}
 
+			//
+			// Initialize asset holders at genesis
+			walkeys, err := acrypto.CreateWalletKeyFiles(hsecret, hcnt, defaultWalkeyDirPath)
+			if err != nil {
+				return err
+			}
+			logger.Info("Generated initial holder's wallet key files", "path", defaultWalkeyDirPath)
+
+			amt := initTotalSupply / int64(len(walkeys))
+			ramt := initTotalSupply % int64(len(walkeys))
 			holders := make([]*genesis.GenesisAssetHolder, len(walkeys))
 			for i, wk := range walkeys {
+				if i == len(walkeys)-1 {
+					amt += ramt
+				}
 				holders[i] = &genesis.GenesisAssetHolder{
 					Address: wk.Address,
-					Balance: uint256.MustFromDecimal("100000000000000000000000000"), // 100_000_000 * 1_000_000_000_000_000_000
+					Balance: btztypes.ToFons(uint64(amt)), // amt * 10^18
 				}
 			}
 			logger.Debug("GenesisAssetHolder", "holders count", len(holders))
 
+			//
+			// Create Governance Parameters at genesis
 			blockInterval, err := time.ParseDuration(assumedBlockInterval)
 			if err != nil {
 				return err
 			}
 			govParams := types.NewGovParams(int(blockInterval.Seconds()))
 			govParams.GetValues().InflationCycleBlocks = inflationCycleBlocks
+			govParams.GetValues().XMaxTotalSupply = btztypes.ToFons(uint64(maxTotalSupply)).Bytes()
 
 			genDoc, err = genesis.NewGenesisDoc(chainID, valset, holders, govParams)
 			if err != nil {

--- a/cmd/commands/init_test.go
+++ b/cmd/commands/init_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/beatoz/beatoz-go/libs/jsonx"
 	types2 "github.com/beatoz/beatoz-go/types"
 	"github.com/beatoz/beatoz-go/types/bytes"
-	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 	tmcfg "github.com/tendermint/tendermint/config"
 	tmjson "github.com/tendermint/tendermint/libs/json"
@@ -88,9 +87,10 @@ func Test_InitialAmounts(t *testing.T) {
 		}
 		require.Equal(t, params.InitVotingPower, actualInitPower)
 
+		fmt.Println("actualInitPower", actualInitPower)
 		//
 		// initial supply
-		actualInitSupply := uint256.NewInt(uint64(actualInitPower))
+		actualInitSupply := types2.ToFons(uint64(actualInitPower))
 		for _, holder := range appState.AssetHolders {
 			_ = actualInitSupply.Add(actualInitSupply, holder.Balance)
 		}

--- a/cmd/commands/init_test.go
+++ b/cmd/commands/init_test.go
@@ -1,0 +1,118 @@
+package commands
+
+import (
+	"fmt"
+	"github.com/beatoz/beatoz-go/ctrlers/types"
+	"github.com/beatoz/beatoz-go/genesis"
+	"github.com/beatoz/beatoz-go/libs/jsonx"
+	types2 "github.com/beatoz/beatoz-go/types"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+	tmcfg "github.com/tendermint/tendermint/config"
+	tmjson "github.com/tendermint/tendermint/libs/json"
+	tmlog "github.com/tendermint/tendermint/libs/log"
+	tmtypes "github.com/tendermint/tendermint/types"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func Test_InitialAmounts(t *testing.T) {
+
+	logger = tmlog.NewNopLogger()
+	config := rootConfig
+	config.RootDir = filepath.Join(os.TempDir(), "init-cmd-test")
+
+	failCase := 0
+	successCase := 0
+
+	for op := 0; op < 100; op++ {
+		require.NoError(t, os.RemoveAll(config.RootDir))
+		tmcfg.EnsureRoot(config.RootDir)
+
+		// gloval variables
+		beatozChainID = "init-test-chain-id"
+		holderCnt = rand.Intn(100) + 1
+		privValCnt = rand.Intn(100) + 1
+		assumedBlockInterval = fmt.Sprintf("%ds", rand.Int31n(3600)+1)
+		inflationCycleBlocks = rand.Int63n(types.WeekSeconds*8) + 1
+		maxTotalSupply = rand.Int63n(1000) + 100
+		initTotalSupply = rand.Int63n(1000) + 100
+		initVotingPower = rand.Int63n(1000) + 100
+
+		vsecrets := make([][]byte, privValCnt)
+		for i, _ := range vsecrets {
+			vsecrets[i] = []byte{0x1}
+		}
+		hsecrets := make([][]byte, holderCnt)
+		for i, _ := range hsecrets {
+			hsecrets[i] = []byte{0x1}
+		}
+
+		err := InitFilesWith(beatozChainID, config, privValCnt, nil, holderCnt, nil)
+		if initTotalSupply > maxTotalSupply || initVotingPower > initTotalSupply {
+			require.Error(t, err)
+			failCase++
+			continue
+		}
+
+		require.NoError(t, err)
+
+		// check values in genesis.json
+		// Calculate SHA-256 hash of the genesis file.
+		f, err := os.Open(config.GenesisFile())
+		require.NoError(t, err)
+		defer f.Close()
+
+		fi, err := f.Stat()
+		require.NoError(t, err)
+
+		jz := make([]byte, fi.Size())
+		_, err = f.Read(jz)
+		require.NoError(t, err)
+
+		genDoc := &tmtypes.GenesisDoc{}
+		require.NoError(t, tmjson.Unmarshal(jz, genDoc))
+
+		//
+		// chain id
+		require.Equal(t, beatozChainID, genDoc.ChainID)
+
+		appState := genesis.GenesisAppState{}
+		require.NoError(t, jsonx.Unmarshal(genDoc.AppState, &appState))
+
+		//
+		// voting power
+		actualInitPower := int64(0)
+		for _, val := range genDoc.Validators {
+			actualInitPower += val.Power
+		}
+		require.Equal(t, initVotingPower, actualInitPower)
+
+		//
+		// initial supply
+		actualInitSupply := uint256.NewInt(0)
+		for _, holder := range appState.AssetHolders {
+			_ = actualInitSupply.Add(actualInitSupply, holder.Balance)
+		}
+		require.Equal(t, types2.ToFons(uint64(initTotalSupply)).Dec(), actualInitSupply.Dec())
+
+		//
+		// GovParams
+		govParams := appState.GovParams
+		bintv, err := time.ParseDuration(assumedBlockInterval)
+		require.NoError(t, err)
+		require.Equal(t, int32(bintv.Seconds()), govParams.AssumedBlockInterval(), assumedBlockInterval)
+		require.Equal(t, inflationCycleBlocks, govParams.InflationCycleBlocks())
+		require.Equal(t, types2.ToFons(uint64(maxTotalSupply)).Dec(), govParams.MaxTotalSupply().Dec())
+
+		require.NoError(t, os.RemoveAll(config.RootDir))
+
+		successCase++
+	}
+
+	require.NotEqual(t, 0, failCase, "no fail case")
+	require.NotEqual(t, 0, successCase, "no success case")
+}

--- a/cmd/commands/run_node.go
+++ b/cmd/commands/run_node.go
@@ -19,7 +19,8 @@ import (
 )
 
 var (
-	genesisHash []byte
+	genesisHash             []byte
+	privValSecretFeederAddr string
 )
 
 // AddNodeFlags exposes some common configuration options on the command-line

--- a/ctrlers/mocks/block_funcs.go
+++ b/ctrlers/mocks/block_funcs.go
@@ -64,8 +64,7 @@ func NextBlockCtxOf(bctx *ctrlertypes.BlockContext) *ctrlertypes.BlockContext {
 }
 
 func DoBeginBlock(ctrlers ...ctrlertypes.IBlockHandler) error {
-	bctx := CurrBlockCtx() //mocks.NextBlockCtx()
-	//fmt.Println("DoBeginBlock for", bctx.Height())
+	bctx := CurrBlockCtx()
 	for _, ctr := range ctrlers {
 		_, err := ctr.BeginBlock(bctx)
 		if err != nil {
@@ -90,7 +89,6 @@ func DoRunTrx(ctrler ctrlertypes.ITrxHandler, txctxs ...*ctrlertypes.TrxContext)
 
 func DoEndBlock(ctrlers ...ctrlertypes.IBlockHandler) error {
 	bctx := CurrBlockCtx()
-	//fmt.Println("DoEndBlock for", bctx.Height())
 	for _, ctr := range ctrlers {
 		_, err := ctr.EndBlock(bctx)
 		if err != nil {
@@ -110,7 +108,6 @@ func DoCommit(ctrlers ...ctrlertypes.IBlockHandler) error {
 	}
 	lastBlockCtx = currBlockCtx
 	currBlockCtx = NextBlockCtxOf(lastBlockCtx)
-	//fmt.Printf("DoCommit - last: %v, curr: %v\n", lastBlockCtx.Height(), currBlockCtx.Height())
 	return nil
 }
 
@@ -144,5 +141,6 @@ func DoAllProcessTo(height int64, ctrlers ...ctrlertypes.IBlockHandler) error {
 			return err
 		}
 	}
+	fmt.Println("DoAllProcessTo - current height:", currBlockCtx.Height())
 	return nil
 }

--- a/ctrlers/supply/ctrler_mint.go
+++ b/ctrlers/supply/ctrler_mint.go
@@ -121,16 +121,15 @@ func computeIssuanceAndRewardRoutine(reqCh chan *reqMint, respCh chan *respMint)
 		sumMintedAmt := uint256.NewInt(0)
 		{
 			remainder := decimal.Zero
-			precision := int32(6)
 
 			for i, benef := range beneficiaries {
 				wi := benef.Weight() //.Truncate(precision) // Truncate is too expensive.
 
 				// for all delegators
-				rwd, _ := rwdToAll.Mul(wi).QuoRem(waAll, precision)
+				rwd, _ := rwdToAll.Mul(wi).QuoRem(waAll, int32(decimal.DivisionPrecision))
 				// for only validators
 				if benef.IsValidator() {
-					_rwd, _ := rwdToVals.Mul(wi).QuoRem(waVals, precision)
+					_rwd, _ := rwdToVals.Mul(wi).QuoRem(waVals, int32(decimal.DivisionPrecision))
 					rwd = rwd.Add(_rwd)
 				}
 
@@ -168,7 +167,6 @@ func Si(height, blockIntv int64, adjustedHeight int64, adjustedSupply, smax *uin
 	_lambda := decimal.New(int64(lambda), -3)
 	decLambdaAddOne := _lambda.Add(decimal.New(1, 0))
 	expWHid := wa.Mul(H(height-adjustedHeight, blockIntv))
-
 	numer := decimal.NewFromBigInt(new(uint256.Int).Sub(smax, adjustedSupply).ToBig(), 0)
 	denom := decLambdaAddOne.Pow(expWHid)
 

--- a/ctrlers/supply/ctrler_mint_test.go
+++ b/ctrlers/supply/ctrler_mint_test.go
@@ -68,7 +68,7 @@ func Test_Mint(t *testing.T) {
 	////
 
 	preRewards := make(map[string]*uint256.Int)
-	for currHeight := int64(2); currHeight < govMock.InflationCycleBlocks()*1000; currHeight += govMock.InflationCycleBlocks() {
+	for currHeight := govMock.InflationCycleBlocks(); /*int64(2)*/ currHeight < govMock.InflationCycleBlocks()*1000; currHeight += govMock.InflationCycleBlocks() {
 		// expect x minting
 		weightInfo, xerr := vpowMock.ComputeWeight(
 			currHeight,

--- a/ctrlers/supply/ctrler_test.go
+++ b/ctrlers/supply/ctrler_test.go
@@ -27,7 +27,7 @@ func init() {
 	config.SetRoot(rootDir)
 
 	govMock = govmock.NewGovHandlerMock(types.DefaultGovParams())
-	govMock.GetValues().InflationCycleBlocks = 10
+	govMock.GetValues().InflationCycleBlocks = types.WeekSeconds
 	acctMock = acctmock.NewAcctHandlerMock(1000)
 	//acctMock.Iterate(func(idx int, w *web3.Wallet) bool {
 	//	w.GetAccount().SetBalance(btztypes.ToFons(1_000_000_000))

--- a/ctrlers/vpower/ctrler_weight.go
+++ b/ctrlers/vpower/ctrler_weight.go
@@ -40,7 +40,7 @@ func (ctrler *VPowerCtrler) ComputeWeight(
 			ptr, _ := item.(*BlockCount)
 			c = *ptr
 		}
-		signRate, _ := decimal.NewFromInt(int64(c)).QuoRem(decimal.NewFromInt(inflationCycle), 6)
+		signRate, _ := decimal.NewFromInt(int64(c)).QuoRem(decimal.NewFromInt(inflationCycle), DivisionPrecision)
 		signRate = decimal.NewFromInt(1).Sub(signRate) // = 1 - missedBlock/inflationCycle
 
 		for _, from := range val.Delegators {
@@ -78,14 +78,6 @@ func (ctrler *VPowerCtrler) ComputeWeight(
 			height, ripeningBlocks, tau, totalSupply)
 		weightInfo.Add(addr, benefW, benefPowChunks.signW, benefPowChunks.val)
 	}
-
-	//totalSupplyPower := decimal.NewFromBigInt(totalSupply.ToBig(), 0).Div(decimal.New(1, int32(types.DECIMAL)))
-	//vpowW := Scaled64PowerChunk(allPowChunks, height, ripeningBlocks, tau)
-	//vpowW, _ = vpowW.QuoRem(totalSupplyPower, int32(types.DECIMAL))
-	//// weightInfo.SumWeight is equal to vpowW
-	//if vpowW.Equal(weightInfo.SumWeight()) == false {
-	//	panic(fmt.Errorf("vpowW(%v) != weightInfo.SumWeight(%v)", vpowW, weightInfo.SumWeight()))
-	//}
 
 	return weightInfo, nil
 }

--- a/ctrlers/vpower/ctrler_weight.go
+++ b/ctrlers/vpower/ctrler_weight.go
@@ -40,7 +40,7 @@ func (ctrler *VPowerCtrler) ComputeWeight(
 			ptr, _ := item.(*BlockCount)
 			c = *ptr
 		}
-		signRate, _ := decimal.NewFromInt(int64(c)).QuoRem(decimal.NewFromInt(inflationCycle), DivisionPrecision)
+		signRate, _ := decimal.NewFromInt(int64(c)).QuoRem(decimal.NewFromInt(inflationCycle), GetDivisionPrecision())
 		signRate = decimal.NewFromInt(1).Sub(signRate) // = 1 - missedBlock/inflationCycle
 
 		for _, from := range val.Delegators {

--- a/ctrlers/vpower/ctrler_weight_test.go
+++ b/ctrlers/vpower/ctrler_weight_test.go
@@ -65,7 +65,7 @@ func Test_VPowerCtrler_ComputeWeight(t *testing.T) {
 		// WaEx64ByPowerChunks
 		w_waex64pc := WaEx64ByPowerChunk(powChunks0, h, govMock.RipeningBlocks(), govMock.BondingBlocksWeightPermil(), totalSupply)
 		//fmt.Println("--- WaEx64ByPowerChunk return", w_waex64pc)
-		w_waex64pc = w_waex64pc.Truncate(6)
+		w_waex64pc = w_waex64pc.Truncate(ResultPrecision)
 
 		// ComputeWeight
 		weightComputed, xerr := ctrler.ComputeWeight(
@@ -87,13 +87,13 @@ func Test_VPowerCtrler_ComputeWeight(t *testing.T) {
 		require.Equal(t, expectedValsSumWeights, weightComputed.ValWeight())
 
 		//fmt.Println("--- ComputeWeight return", weightComputed.SumWeight())
-		w_computed := weightComputed.SumWeight().Truncate(6)
+		w_computed := weightComputed.SumWeight().Truncate(ResultPrecision)
 
 		sumIndW := decimal.Zero
 		for _, b := range weightComputed.Beneficiaries() {
 			sumIndW = sumIndW.Add(b.Weight())
 		}
-		sumIndW = sumIndW.Truncate(6)
+		sumIndW = sumIndW.Truncate(ResultPrecision)
 
 		require.Equal(t, w_computed.String(), sumIndW.String())
 		require.True(t, w_waex64pc.LessThanOrEqual(ctrlertypes.DecimalOne), "WaEx64ByPowerChunks", w_waex64pc, "height", h)

--- a/ctrlers/vpower/ctrler_weight_test.go
+++ b/ctrlers/vpower/ctrler_weight_test.go
@@ -65,7 +65,7 @@ func Test_VPowerCtrler_ComputeWeight(t *testing.T) {
 		// WaEx64ByPowerChunks
 		w_waex64pc := WaEx64ByPowerChunk(powChunks0, h, govMock.RipeningBlocks(), govMock.BondingBlocksWeightPermil(), totalSupply)
 		//fmt.Println("--- WaEx64ByPowerChunk return", w_waex64pc)
-		w_waex64pc = w_waex64pc.Truncate(ResultPrecision)
+		w_waex64pc = w_waex64pc.Truncate(GetGuaranteedPrecision())
 
 		// ComputeWeight
 		weightComputed, xerr := ctrler.ComputeWeight(
@@ -87,13 +87,13 @@ func Test_VPowerCtrler_ComputeWeight(t *testing.T) {
 		require.Equal(t, expectedValsSumWeights, weightComputed.ValWeight())
 
 		//fmt.Println("--- ComputeWeight return", weightComputed.SumWeight())
-		w_computed := weightComputed.SumWeight().Truncate(ResultPrecision)
+		w_computed := weightComputed.SumWeight().Truncate(GetGuaranteedPrecision())
 
 		sumIndW := decimal.Zero
 		for _, b := range weightComputed.Beneficiaries() {
 			sumIndW = sumIndW.Add(b.Weight())
 		}
-		sumIndW = sumIndW.Truncate(ResultPrecision)
+		sumIndW = sumIndW.Truncate(GetGuaranteedPrecision())
 
 		require.Equal(t, w_computed.String(), sumIndW.String())
 		require.True(t, w_waex64pc.LessThanOrEqual(ctrlertypes.DecimalOne), "WaEx64ByPowerChunks", w_waex64pc, "height", h)

--- a/ctrlers/vpower/weight.go
+++ b/ctrlers/vpower/weight.go
@@ -12,7 +12,7 @@ var (
 )
 
 func init() {
-	SetDivisionPrecision(8)
+	SetDivisionPrecision(9)
 }
 
 func SetDivisionPrecision(precision int32) {

--- a/ctrlers/vpower/weight_test.go
+++ b/ctrlers/vpower/weight_test.go
@@ -5,6 +5,7 @@ import (
 	ctrlertypes "github.com/beatoz/beatoz-go/ctrlers/types"
 	"github.com/beatoz/beatoz-go/types"
 	"github.com/beatoz/beatoz-go/types/bytes"
+	"github.com/holiman/uint256"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/require"
 	"math/rand"
@@ -50,9 +51,9 @@ func Test_Wi(t *testing.T) {
 
 		for _, vpobj := range vpObjs {
 			wi0 := oldWi(vpobj.vpow, vpobj.vdur, powerRipeningCycle, 200, decimal.NewFromBigInt(totalSupply.ToBig(), 0))
-			wi0 = wi0.Truncate(ResultPrecision)
+			wi0 = wi0.Truncate(GetGuaranteedPrecision())
 			wi1 := Wi(vpobj.vpow, vpobj.vdur, powerRipeningCycle, 200, decimal.NewFromBigInt(totalSupply.ToBig(), 0))
-			wi1 = wi1.Truncate(ResultPrecision)
+			wi1 = wi1.Truncate(GetGuaranteedPrecision())
 			require.Equal(t, wi0, wi1, "not equal", "wi0", wi0, "wi1", wi1)
 
 			_wa := wa.Add(wi1)
@@ -87,27 +88,27 @@ func Test_SumWi_Wa_WaEx_WaEx64(t *testing.T) {
 			vpows = append(vpows, vpobj.vpow)
 			vdurs = append(vdurs, vpobj.vdur)
 		}
-		w_sumwi = w_sumwi.Truncate(ResultPrecision)
+		w_sumwi = w_sumwi.Truncate(GetGuaranteedPrecision())
 		dur0 += time.Since(start)
 		//fmt.Println("sum of Wi", w_sumwi)
 
 		// Wa
 		start = time.Now()
 		w_wa := Wa(vpows, vdurs, powerRipeningCycle, tau, decimal.NewFromBigInt(totalSupply.ToBig(), 0))
-		w_wa = w_wa.Truncate(ResultPrecision)
+		w_wa = w_wa.Truncate(GetGuaranteedPrecision())
 		dur1 += time.Since(start)
 		//fmt.Println("Wa return", w_wa)
 
 		// WaEx
 		start = time.Now()
 		w_waex := WaEx(vpows, vdurs, powerRipeningCycle, tau, decimal.NewFromBigInt(totalSupply.ToBig(), 0))
-		w_waex = w_waex.Truncate(ResultPrecision)
+		w_waex = w_waex.Truncate(GetGuaranteedPrecision())
 		dur2 += time.Since(start)
 
 		// WaEx64
 		start = time.Now()
 		w_waex64 := WaEx64(vpows, vdurs, powerRipeningCycle, tau, totalSupply)
-		w_waex64 = w_waex64.Truncate(ResultPrecision)
+		w_waex64 = w_waex64.Truncate(GetGuaranteedPrecision())
 		dur3 += time.Since(start)
 
 		require.True(t, w_sumwi.LessThanOrEqual(ctrlertypes.DecimalOne), "SumWi", w_sumwi, "nth", n)
@@ -165,43 +166,43 @@ func Test_WaEx64Pc_Weight64Pc(t *testing.T) {
 			wi := Wi(pow, dur, powerRipeningCycle, tau, decimal.NewFromBigInt(totalSupply.ToBig(), 0))
 			w_sumwi = w_sumwi.Add(wi)
 		}
-		w_sumwi = w_sumwi.Truncate(ResultPrecision)
+		w_sumwi = w_sumwi.Truncate(GetGuaranteedPrecision())
 		dur0 += time.Since(start)
 		//fmt.Println("sum of Wi", w_sumwi)
 
 		// Wa
 		start = time.Now()
 		w_wa := Wa(vpows, vdurs, powerRipeningCycle, tau, decimal.NewFromBigInt(totalSupply.ToBig(), 0))
-		w_wa = w_wa.Truncate(ResultPrecision)
+		w_wa = w_wa.Truncate(GetGuaranteedPrecision())
 		dur1 += time.Since(start)
 		//fmt.Println("Wa return", w_wa)
 
 		// WaEx
 		start = time.Now()
 		w_waex := WaEx(vpows, vdurs, powerRipeningCycle, tau, decimal.NewFromBigInt(totalSupply.ToBig(), 0))
-		w_waex = w_waex.Truncate(ResultPrecision)
+		w_waex = w_waex.Truncate(GetGuaranteedPrecision())
 		dur2 += time.Since(start)
 
 		// WaEx64
 		start = time.Now()
 		w_waex64 := WaEx64(vpows, vdurs, powerRipeningCycle, tau, totalSupply)
-		w_waex64 = w_waex64.Truncate(ResultPrecision)
+		w_waex64 = w_waex64.Truncate(GetGuaranteedPrecision())
 		dur3 += time.Since(start)
 		//fmt.Println("WaEx64 return", w_waex64)
 
 		// WaEx64ByPowerChunks
 		start = time.Now()
 		w_waex64pc := WaEx64ByPowerChunk(powChunks, currHeight, powerRipeningCycle, tau, totalSupply)
-		w_waex64pc = w_waex64pc.Truncate(ResultPrecision)
+		w_waex64pc = w_waex64pc.Truncate(GetGuaranteedPrecision())
 		dur4 += time.Since(start)
 		//fmt.Println("WaEx64ByPowerChunk return", w_waex64pc)
 
 		// Weight64ByPowerChunks
 		start = time.Now()
 		w_w64pc := Scaled64PowerChunk(powChunks, currHeight, powerRipeningCycle, tau)
-		_totalSupply := decimal.NewFromBigInt(totalSupply.ToBig(), 0).Div(decimal.New(1, int32(types.DECIMAL)))
-		w_w64pc, _ = w_w64pc.QuoRem(_totalSupply, DivisionPrecision)
-		w_w64pc = w_w64pc.Truncate(ResultPrecision)
+		_totalSupply := decimal.NewFromBigInt(totalSupply.ToBig(), -1*int32(types.DECIMAL))
+		w_w64pc, _ = w_w64pc.QuoRem(_totalSupply, GetDivisionPrecision())
+		w_w64pc = w_w64pc.Truncate(GetGuaranteedPrecision())
 		dur5 += time.Since(start)
 		//fmt.Println("Scaled64PowerChunk return", w_w64pc)
 
@@ -211,8 +212,8 @@ func Test_WaEx64Pc_Weight64Pc(t *testing.T) {
 		w_w64pc_patial0 := Scaled64PowerChunk(powChunks[:rdx], currHeight, powerRipeningCycle, tau)
 		w_w64pc_patial1 := Scaled64PowerChunk(powChunks[rdx:], currHeight, powerRipeningCycle, tau)
 		w_w64pc_patial := w_w64pc_patial0.Add(w_w64pc_patial1)
-		w_w64pc_patial, _ = w_w64pc_patial.QuoRem(_totalSupply, DivisionPrecision)
-		w_w64pc_patial = w_w64pc_patial.Truncate(ResultPrecision)
+		w_w64pc_patial, _ = w_w64pc_patial.QuoRem(_totalSupply, GetDivisionPrecision())
+		w_w64pc_patial = w_w64pc_patial.Truncate(GetGuaranteedPrecision())
 		dur6 += time.Since(start)
 		//fmt.Println("Scaled64PowerChunk return", w_w64pc)
 
@@ -313,4 +314,129 @@ func Benchmark_WaEx64(b *testing.B) {
 		}
 		_ = WaEx64(vpows, vdurs, powerRipeningCycle, tau, totalSupply)
 	}
+}
+
+func Test_temp(t *testing.T) {
+	SetDivisionPrecision(1)
+	tau := decimal.New(int64(2), -3)
+	fmt.Println("tau", tau)
+	tau = tau.Mul(decimal.NewFromInt(2))
+	fmt.Println("tau", tau)
+	tau, _ = tau.QuoRem(decimal.NewFromInt(2), int32(types.DECIMAL))
+	fmt.Println("tau", tau)
+}
+
+func Benchmark_Precision_6(b *testing.B) {
+	SetDivisionPrecision(3)
+
+	totalSupply := types.ToFons(uint64(123_123_456_789))
+	votingPower := int64(123_456_789)
+	powerPeriod := powerRipeningCycle / 3
+
+	for i := 0; i < b.N; i++ {
+		tau := decimal.New(int64(200), -3)
+		keppa := ctrlertypes.DecimalOne.Sub(tau)
+
+		vpPart := tau.Mul(decimal.NewFromInt(powerPeriod)).
+			Div(decimal.NewFromInt(powerRipeningCycle)).
+			Add(keppa).
+			Mul(decimal.NewFromInt(votingPower)) // 106995924.952263
+		decTotalSupply := decimal.NewFromBigInt(totalSupply.ToBig(), -1*int32(types.DECIMAL))
+		_, _ = vpPart.QuoRem(decTotalSupply, int32(decimal.DivisionPrecision))
+		//fmt.Println("Precision 6", "vpPart", vpPart, "w", w)
+	}
+}
+
+func Benchmark_Precision_16(b *testing.B) {
+	SetDivisionPrecision(16)
+
+	totalSupply := types.ToFons(uint64(123_123_456_789))
+	votingPower := int64(123_456_789)
+	powerPeriod := powerRipeningCycle / 3
+
+	for i := 0; i < b.N; i++ {
+		tau := decimal.New(int64(200), -3)
+		keppa := ctrlertypes.DecimalOne.Sub(tau)
+
+		vpPart := tau.Mul(decimal.NewFromInt(powerPeriod)).
+			Div(decimal.NewFromInt(powerRipeningCycle)).
+			Add(keppa).
+			Mul(decimal.NewFromInt(votingPower)) // 106995883.8000000041152263
+		decTotalSupply := decimal.NewFromBigInt(totalSupply.ToBig(), -1*int32(types.DECIMAL))
+		_, _ = vpPart.QuoRem(decTotalSupply, int32(decimal.DivisionPrecision))
+		//fmt.Println("Precision 6", "vpPart", vpPart, "w", w)
+	}
+}
+
+func Benchmark_Decimal_NewExp(b *testing.B) {
+	totalSupply := types.ToFons(uint64(123_123_456_789))
+
+	for i := 0; i < b.N; i++ {
+		_ = decimal.NewFromBigInt(totalSupply.ToBig(), -1*int32(types.DECIMAL))
+	}
+}
+
+func Benchmark_Decimal_NewDiv(b *testing.B) {
+	totalSupply := types.ToFons(uint64(123_123_456_789))
+
+	for i := 0; i < b.N; i++ {
+		_ = decimal.NewFromBigInt(totalSupply.ToBig(), 0).Div(decimal.New(1, int32(types.DECIMAL)))
+	}
+}
+
+func Test_Precision(t *testing.T) {
+
+	totalSupply := uint256.MustFromDecimal("789123456789123456789123456789")
+	votingPower := int64(123_456_789)
+	powerPeriod := powerRipeningCycle / 3
+
+	//
+	// Precision 6
+	SetDivisionPrecision(8)
+	fmt.Println("precision           ", GetDivisionPrecision())
+	fmt.Println("votingPower         ", decimal.NewFromInt(votingPower))
+
+	tau := decimal.New(int64(200), -3)
+	fmt.Println("tau                 ", tau)
+	keppa := ctrlertypes.DecimalOne.Sub(tau)
+	fmt.Println("keppa               ", keppa)
+
+	vpPart := tau.Mul(decimal.NewFromInt(powerPeriod))
+	fmt.Println("vpPart*tau          ", vpPart)
+	vpPart, _ = vpPart.QuoRem(decimal.NewFromInt(powerRipeningCycle), GetDivisionPrecision())
+	fmt.Println("vpPart/ripeningCycle", vpPart)
+	vpPart = vpPart.Add(keppa)
+	fmt.Println("vpPart+keppa        ", vpPart)
+	vpPart = vpPart.Mul(decimal.NewFromInt(votingPower)) // 106995883.8000000041152263
+	fmt.Println("vpPart*vpower       ", vpPart)
+	decTotalSupply := decimal.NewFromBigInt(totalSupply.ToBig(), -1*int32(types.DECIMAL))
+	fmt.Println("decTotalSupply      ", decTotalSupply)
+	q, r := vpPart.QuoRem(decTotalSupply, int32(GetDivisionPrecision()))
+	fmt.Println("result", q, "remainder", r)
+
+	fmt.Println("--------------------------")
+
+	//
+	// Precision 16 (default)
+	SetDivisionPrecision(16)
+	fmt.Println("precision           ", GetDivisionPrecision())
+	fmt.Println("votingPower         ", decimal.NewFromInt(votingPower))
+
+	tau = decimal.New(int64(200), -3)
+	fmt.Println("tau                 ", tau)
+	keppa = ctrlertypes.DecimalOne.Sub(tau)
+	fmt.Println("keppa               ", keppa)
+
+	vpPart = tau.Mul(decimal.NewFromInt(powerPeriod))
+	fmt.Println("vpPart*tau          ", vpPart)
+	vpPart, _ = vpPart.QuoRem(decimal.NewFromInt(powerRipeningCycle), GetDivisionPrecision())
+	fmt.Println("vpPart/ripeningCycle", vpPart)
+	vpPart = vpPart.Add(keppa)
+	fmt.Println("vpPart+keppa        ", vpPart)
+	vpPart = vpPart.Mul(decimal.NewFromInt(votingPower)) // 106995883.8000000041152263
+	fmt.Println("vpPart*vpower       ", vpPart)
+	decTotalSupply = decimal.NewFromBigInt(totalSupply.ToBig(), -1*int32(types.DECIMAL))
+	fmt.Println("decTotalSupply      ", decTotalSupply)
+	q, r = vpPart.QuoRem(decTotalSupply, int32(GetDivisionPrecision()))
+	fmt.Println("result", q, "remainder", r)
 }

--- a/ctrlers/vpower/weight_test.go
+++ b/ctrlers/vpower/weight_test.go
@@ -50,9 +50,9 @@ func Test_Wi(t *testing.T) {
 
 		for _, vpobj := range vpObjs {
 			wi0 := oldWi(vpobj.vpow, vpobj.vdur, powerRipeningCycle, 200, decimal.NewFromBigInt(totalSupply.ToBig(), 0))
-			wi0 = wi0.Truncate(6)
+			wi0 = wi0.Truncate(ResultPrecision)
 			wi1 := Wi(vpobj.vpow, vpobj.vdur, powerRipeningCycle, 200, decimal.NewFromBigInt(totalSupply.ToBig(), 0))
-			wi1 = wi1.Truncate(6)
+			wi1 = wi1.Truncate(ResultPrecision)
 			require.Equal(t, wi0, wi1, "not equal", "wi0", wi0, "wi1", wi1)
 
 			_wa := wa.Add(wi1)
@@ -87,27 +87,27 @@ func Test_SumWi_Wa_WaEx_WaEx64(t *testing.T) {
 			vpows = append(vpows, vpobj.vpow)
 			vdurs = append(vdurs, vpobj.vdur)
 		}
-		w_sumwi = w_sumwi.Truncate(6)
+		w_sumwi = w_sumwi.Truncate(ResultPrecision)
 		dur0 += time.Since(start)
 		//fmt.Println("sum of Wi", w_sumwi)
 
 		// Wa
 		start = time.Now()
 		w_wa := Wa(vpows, vdurs, powerRipeningCycle, tau, decimal.NewFromBigInt(totalSupply.ToBig(), 0))
-		w_wa = w_wa.Truncate(6)
+		w_wa = w_wa.Truncate(ResultPrecision)
 		dur1 += time.Since(start)
 		//fmt.Println("Wa return", w_wa)
 
 		// WaEx
 		start = time.Now()
 		w_waex := WaEx(vpows, vdurs, powerRipeningCycle, tau, decimal.NewFromBigInt(totalSupply.ToBig(), 0))
-		w_waex = w_waex.Truncate(6)
+		w_waex = w_waex.Truncate(ResultPrecision)
 		dur2 += time.Since(start)
 
 		// WaEx64
 		start = time.Now()
 		w_waex64 := WaEx64(vpows, vdurs, powerRipeningCycle, tau, totalSupply)
-		w_waex64 = w_waex64.Truncate(6)
+		w_waex64 = w_waex64.Truncate(ResultPrecision)
 		dur3 += time.Since(start)
 
 		require.True(t, w_sumwi.LessThanOrEqual(ctrlertypes.DecimalOne), "SumWi", w_sumwi, "nth", n)
@@ -165,34 +165,34 @@ func Test_WaEx64Pc_Weight64Pc(t *testing.T) {
 			wi := Wi(pow, dur, powerRipeningCycle, tau, decimal.NewFromBigInt(totalSupply.ToBig(), 0))
 			w_sumwi = w_sumwi.Add(wi)
 		}
-		w_sumwi = w_sumwi.Truncate(6)
+		w_sumwi = w_sumwi.Truncate(ResultPrecision)
 		dur0 += time.Since(start)
 		//fmt.Println("sum of Wi", w_sumwi)
 
 		// Wa
 		start = time.Now()
 		w_wa := Wa(vpows, vdurs, powerRipeningCycle, tau, decimal.NewFromBigInt(totalSupply.ToBig(), 0))
-		w_wa = w_wa.Truncate(6)
+		w_wa = w_wa.Truncate(ResultPrecision)
 		dur1 += time.Since(start)
 		//fmt.Println("Wa return", w_wa)
 
 		// WaEx
 		start = time.Now()
 		w_waex := WaEx(vpows, vdurs, powerRipeningCycle, tau, decimal.NewFromBigInt(totalSupply.ToBig(), 0))
-		w_waex = w_waex.Truncate(6)
+		w_waex = w_waex.Truncate(ResultPrecision)
 		dur2 += time.Since(start)
 
 		// WaEx64
 		start = time.Now()
 		w_waex64 := WaEx64(vpows, vdurs, powerRipeningCycle, tau, totalSupply)
-		w_waex64 = w_waex64.Truncate(6)
+		w_waex64 = w_waex64.Truncate(ResultPrecision)
 		dur3 += time.Since(start)
 		//fmt.Println("WaEx64 return", w_waex64)
 
 		// WaEx64ByPowerChunks
 		start = time.Now()
 		w_waex64pc := WaEx64ByPowerChunk(powChunks, currHeight, powerRipeningCycle, tau, totalSupply)
-		w_waex64pc = w_waex64pc.Truncate(6)
+		w_waex64pc = w_waex64pc.Truncate(ResultPrecision)
 		dur4 += time.Since(start)
 		//fmt.Println("WaEx64ByPowerChunk return", w_waex64pc)
 
@@ -200,8 +200,8 @@ func Test_WaEx64Pc_Weight64Pc(t *testing.T) {
 		start = time.Now()
 		w_w64pc := Scaled64PowerChunk(powChunks, currHeight, powerRipeningCycle, tau)
 		_totalSupply := decimal.NewFromBigInt(totalSupply.ToBig(), 0).Div(decimal.New(1, int32(types.DECIMAL)))
-		w_w64pc, _ = w_w64pc.QuoRem(_totalSupply, int32(types.DECIMAL))
-		w_w64pc = w_w64pc.Truncate(6)
+		w_w64pc, _ = w_w64pc.QuoRem(_totalSupply, DivisionPrecision)
+		w_w64pc = w_w64pc.Truncate(ResultPrecision)
 		dur5 += time.Since(start)
 		//fmt.Println("Scaled64PowerChunk return", w_w64pc)
 
@@ -211,8 +211,8 @@ func Test_WaEx64Pc_Weight64Pc(t *testing.T) {
 		w_w64pc_patial0 := Scaled64PowerChunk(powChunks[:rdx], currHeight, powerRipeningCycle, tau)
 		w_w64pc_patial1 := Scaled64PowerChunk(powChunks[rdx:], currHeight, powerRipeningCycle, tau)
 		w_w64pc_patial := w_w64pc_patial0.Add(w_w64pc_patial1)
-		w_w64pc_patial, _ = w_w64pc_patial.QuoRem(_totalSupply, int32(types.DECIMAL))
-		w_w64pc_patial = w_w64pc_patial.Truncate(6)
+		w_w64pc_patial, _ = w_w64pc_patial.QuoRem(_totalSupply, DivisionPrecision)
+		w_w64pc_patial = w_w64pc_patial.Truncate(ResultPrecision)
 		dur6 += time.Since(start)
 		//fmt.Println("Scaled64PowerChunk return", w_w64pc)
 

--- a/libs/jsonx/jsonx.go
+++ b/libs/jsonx/jsonx.go
@@ -5,14 +5,7 @@ import (
 	"reflect"
 )
 
-var _jsonx = jsoniter.Config{
-	IndentionStep:          2,
-	EscapeHTML:             true,
-	SortMapKeys:            true,
-	ValidateJsonRawMessage: true,
-}.Froze()
-
-//var _jsonx = jsoniter.ConfigCompatibleWithStandardLibrary
+var _jsonx = jsoniter.ConfigCompatibleWithStandardLibrary
 
 var (
 	Marshal       = _jsonx.Marshal       //jsoniter.ConfigCompatibleWithStandardLibrary.Marshal

--- a/test/heper_peer.go
+++ b/test/heper_peer.go
@@ -92,7 +92,16 @@ func (peer *PeerMock) SetPass(pass []byte) {
 }
 
 func (peer *PeerMock) Init(valCnt int) error {
-	return commands.InitFilesWith(peer.ChainID, peer.Config, valCnt, peer.Pass, 500, peer.Pass)
+	initParams := commands.DefaultIniParams()
+	initParams.ChainID = peer.ChainID
+	initParams.ValCnt = valCnt
+	initParams.ValSecret = peer.Pass
+	initParams.HolderCnt = 500
+	initParams.HolderSecret = peer.Pass
+	initParams.InitVotingPower = int64(1_000_000 * valCnt)
+	initParams.InitTotalSupply = int64(100_000_000*500 + 1_000_000*valCnt)
+	initParams.MaxTotalSupply = int64(100_000_000*500 + 1_000_000*valCnt*2)
+	return commands.InitFilesWith(peer.Config, initParams)
 }
 
 func (peer *PeerMock) Start() error {


### PR DESCRIPTION
### Changes in this Pull Request

- **Refactor**: Replaced `init_system` parameters with `InitParams` struct for improved organization and clarity.
- **Bug Fix**: Resolved initialization command issues:
  - Added options: `--init_voting_power`, `--init_total_supply`, and `--max_total_supply`.
  - Ensured `init_voting_power` does not exceed `init_total_supply`.
  - Ensured `init_total_supply` does not exceed `max_total_supply`.
- **Testing Improvements**:
  - Adjusted precision settings to prevent test failures.
  - Set `InflationCycleBlocks` to a smaller value for faster test runs.
- **Other Changes**:
  - Introduced precision constants for division logic.
  - Used `jsoniter.ConfigCompatibleWithStandardLibrary` for JSON handling adjustments.

### Checklist

- [ ] Associated documentation has been updated.
- [ ] Related tests were updated or added.
- [ ] Changes have been verified and reviewed. 