### PR TITLE
Fix panic when genesis has wrong supply values 

### DIFF
--- a/cmd/commands/init_test.go
+++ b/cmd/commands/init_test.go
@@ -87,7 +87,6 @@ func Test_InitialAmounts(t *testing.T) {
 		}
 		require.Equal(t, params.InitVotingPower, actualInitPower)
 
-		fmt.Println("actualInitPower", actualInitPower)
 		//
 		// initial supply
 		actualInitSupply := types2.ToFons(uint64(actualInitPower))

--- a/ctrlers/types/gov_params_test.go
+++ b/ctrlers/types/gov_params_test.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"fmt"
 	"github.com/beatoz/beatoz-go/libs/jsonx"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
@@ -27,7 +28,7 @@ func Test_JsonCodec(t *testing.T) {
 	jz, err := jsonx.MarshalIndent(govParams, "", "  ")
 	require.NoError(t, err)
 
-	//fmt.Println(string(jz))
+	fmt.Println(string(jz))
 
 	govParams2 := &GovParams{}
 	err = jsonx.Unmarshal(jz, govParams2)

--- a/node/app.go
+++ b/node/app.go
@@ -179,11 +179,11 @@ func (ctrler *BeatozApp) InitChain(req abcitypes.RequestInitChain) abcitypes.Res
 		panic(xerr)
 	}
 
-	if xerr := ctrler.govCtrler.InitLedger(&appState); xerr != nil {
+	if xerr := ctrler.govCtrler.InitLedger(appState); xerr != nil {
 		ctrler.logger.Error("BeatozApp", "error", xerr)
 		panic(xerr)
 	}
-	if xerr := ctrler.acctCtrler.InitLedger(&appState); xerr != nil {
+	if xerr := ctrler.acctCtrler.InitLedger(appState); xerr != nil {
 		ctrler.logger.Error("BeatozApp", "error", xerr)
 		panic(xerr)
 	}

--- a/node/app_test.go
+++ b/node/app_test.go
@@ -1,0 +1,48 @@
+package node
+
+import (
+	"github.com/stretchr/testify/require"
+	abcitypes "github.com/tendermint/tendermint/abci/types"
+	"strings"
+	"testing"
+)
+
+func Test_InitChain(t *testing.T) {
+	// max total supply is less than initial total supply
+	req := abcitypes.RequestInitChain{
+		Validators: abcitypes.ValidatorUpdates{
+			{Power: 1}, {Power: 1}, {Power: 1}, // 3000000000000000000
+		},
+		AppStateBytes: []byte(`{
+"assetHolders": [
+	{"address": "AAAAAA", "balance":"1000000000000000000"},
+	{"address": "BBBBBB", "balance":"1000000000000000000"},
+	{"address": "CCCCCC", "balance":"1000000000000000000"}
+],
+"govParams":{
+	"maxTotalSupply":"5999999999999999999"
+}}`)}
+
+	_, _, err := checkRequestInitChain(req)
+	require.Error(t, err)
+	require.True(t, strings.HasPrefix(err.Error(), "error: initial supply"))
+
+	// success case
+	req = abcitypes.RequestInitChain{
+		Validators: abcitypes.ValidatorUpdates{
+			{Power: 1}, {Power: 1}, {Power: 1},
+		},
+		AppStateBytes: []byte(`{
+"assetHolders": [
+	{"address": "AAAAAA", "balance":"1000000000000000000"},
+	{"address": "BBBBBB", "balance":"1000000000000000000"},
+	{"address": "CCCCCC", "balance":"1000000000000000000"}
+],
+"govParams":{
+	"maxTotalSupply":"6000000000000000000"
+}}`)}
+
+	_, genTotalSupply, err := checkRequestInitChain(req)
+	require.NoError(t, err)
+	require.Equal(t, "6000000000000000000", genTotalSupply.Dec())
+}

--- a/test/1_issue32_test.go
+++ b/test/1_issue32_test.go
@@ -46,7 +46,7 @@ func TestIssue32(t *testing.T) {
 	receiverHelper1 := newAcctObj(randRecvAcct1)
 	allAcctHelpers = append(allAcctHelpers, receiverHelper1)
 
-	fmt.Printf("TestIssue32 - sender count (goroutine count): %v\n", senderCnt)
+	fmt.Printf("TestIssue32 - sender count (goroutine count): %v\nWait...\n", senderCnt)
 	for _, v := range senderAcctObjs {
 		wg.Add(1)
 		//go bulkTransferSync(t, &wg, v, []*acctObj{receiverHelper, receiverHelper1}, 50) // 50 txs

--- a/test/helper_utils.go
+++ b/test/helper_utils.go
@@ -87,7 +87,7 @@ func prepareTest(_peers []*PeerMock) {
 		}
 	}
 
-	fmt.Println("Init Holder count", len(wallets))
+	fmt.Println("Init Holder count", len(wallets), "Wait...")
 
 	//
 	// validator's balance is 0 at now,


### PR DESCRIPTION
```
### Changes Introduced
- Fixed the following bugs:
  - Resolved incorrect appState passing to `InitLedger`.
  - Fixed control logic when genesis supply values are incorrect.
  - Addressed JSON marshaling/unmarshaling bugs in `(*GovParams).Un/MarshalJSON`.
  - Fixed bugs related to the `init` command, adding new parameter options (`--init_voting_power`, `--init_total_supply`, `--max_total_supply`) with constraints.
- Refactored by introducing `InitParams` struct for cleaner parameter management.
- Enhanced division logic precision by adding `DivisionPrecision` and `ResultPrecision` constants and adopting a controlled precision mechanism.
- Updated existing codebase to utilize `SetDivisionPrecision` for consistent mathematical operations.

### Test Improvements
- Adjusted precision values to mitigate rounding errors and prevent test failures.
- Reduced `InflationCycleBlocks` in test setups for faster cycle executions.

### Miscellaneous
- Updated JSON processing using `jsoniter.ConfigCompatibleWithStandardLibrary` to streamline serialization.

```