### PR TITLE
Fix RPC panic in calling '/validators' without height

### DIFF
--- a/rpc/functions.go
+++ b/rpc/functions.go
@@ -159,8 +159,5 @@ func TxSearch(
 }
 
 func Validators(ctx *tmrpctypes.Context, heightPtr *int64, pagePtr, perPagePtr *int) (*tmrpccoretypes.ResultValidators, error) {
-	if *heightPtr == 0 {
-		heightPtr = nil
-	}
 	return tmrpccore.Validators(ctx, heightPtr, pagePtr, perPagePtr)
 }


### PR DESCRIPTION
Resolved an issue where the RPC call to `/validators` would result in a panic when no height was provided.