### PR TITLE
Fix gas fee deduction logic and checking account type

### DIFF
--- a/ctrlers/vm/evm/ctrler.go
+++ b/ctrlers/vm/evm/ctrler.go
@@ -120,8 +120,8 @@ func (ctrler *EVMCtrler) BeginBlock(bctx *ctrlertypes.BlockContext) ([]abcitypes
 }
 
 func (ctrler *EVMCtrler) ValidateTrx(ctx *ctrlertypes.TrxContext) xerrors.XError {
-	if ctx.Tx.GetType() != ctrlertypes.TRX_CONTRACT && ctx.Receiver.Code == nil {
-		return xerrors.ErrUnknownTrxType
+	if ctx.Receiver.Code == nil {
+		return xerrors.ErrInvalidAccountType
 	}
 
 	inputData := []byte(nil)

--- a/node/trx_executor.go
+++ b/node/trx_executor.go
@@ -169,8 +169,12 @@ func postRunTrx(ctx *ctrlertypes.TrxContext) xerrors.XError {
 	//	return nil
 	//}
 
+	// In case of EVM Tx, ctx.GasUsed has been already computed in EVMCtrler.
+	if !ctx.IsHandledByEVM() {
+		ctx.GasUsed = ctx.Tx.Gas
+	}
 	// processing fee = gas * gasPrice
-	fee := new(uint256.Int).Mul(ctx.Tx.GasPrice, uint256.NewInt(uint64(ctx.Tx.Gas)))
+	fee := new(uint256.Int).Mul(ctx.Tx.GasPrice, uint256.NewInt(uint64(ctx.GasUsed)))
 	if xerr := ctx.Payer.SubBalance(fee); xerr != nil {
 		return xerr
 	}
@@ -188,6 +192,5 @@ func postRunTrx(ctx *ctrlertypes.TrxContext) xerrors.XError {
 		}
 	}
 	// set used gas
-	ctx.GasUsed = ctx.Tx.Gas
 	return nil
 }


### PR DESCRIPTION
### Changes
- Fixed incorrect gas fee deduction logic for contract transactions.
    - Gas calculation was correct, but the deduction mechanism was faulty.
- Corrected checking account type handling to ensure accurate account classification.

### Related Commits
- 936974a: fix: Gas fee charging logic for contract txs
- c90dd66: fix: Fix checking account type

### Notes
- These fixes improve the correctness of transaction processing and account validation logic.
- Backward compatibility is maintained.
