### PR TITLE
Prevent nondeterministic state during TrxContext.Receiver resolution

### DIFF
--- a/ctrlers/account/ctrler_block.go
+++ b/ctrlers/account/ctrler_block.go
@@ -52,6 +52,9 @@ func (ctrler *AcctCtrler) Commit() ([]byte, int64, xerrors.XError) {
 	ctrler.mtx.Lock()
 	defer ctrler.mtx.Unlock()
 
+	clear(ctrler.newbiesCheck)
+	clear(ctrler.newbiesDeliver)
+
 	h, v, xerr := ctrler.acctState.Commit()
 	return h, v, xerr
 }

--- a/ctrlers/mocks/acct/ctrler_mock.go
+++ b/ctrlers/mocks/acct/ctrler_mock.go
@@ -41,6 +41,10 @@ func (mock *AcctHandlerMock) AddWallet(w *web3.Wallet) {
 	mock.wallets = append(mock.wallets, w)
 }
 
+func (mock *AcctHandlerMock) AddAccount(acct *ctrlertypes.Account) {
+	mock.accounts = append(mock.accounts, acct)
+}
+
 func (mock *AcctHandlerMock) GetWallet(idx int) *web3.Wallet {
 	if idx >= len(mock.wallets) {
 		return nil

--- a/ctrlers/types/block_ctx.go
+++ b/ctrlers/types/block_ctx.go
@@ -21,7 +21,6 @@ type BlockContext struct {
 	blockGasPool   *ethcore.GasPool
 	feeSum         *uint256.Int
 	txsCnt         int
-	evmTxsCnt      int
 	appHash        bytes.HexBytes
 
 	GovHandler    IGovHandler
@@ -50,7 +49,6 @@ func NewBlockContext(bi abcitypes.RequestBeginBlock, g IGovHandler, a IAccountHa
 		blockInfo:     bi,
 		feeSum:        uint256.NewInt(0),
 		txsCnt:        0,
-		evmTxsCnt:     0,
 		appHash:       nil,
 		GovHandler:    g,
 		AcctHandler:   a,
@@ -192,21 +190,11 @@ func (bctx *BlockContext) TxsCnt() int {
 	return bctx.txsCnt
 }
 
-func (bctx *BlockContext) EVMTxsCnt() int {
-	bctx.mtx.RLock()
-	defer bctx.mtx.RUnlock()
-
-	return bctx.evmTxsCnt
-}
-
-func (bctx *BlockContext) AddTxsCnt(d int, isEVMTx bool) {
+func (bctx *BlockContext) AddTxsCnt(d int) {
 	bctx.mtx.Lock()
 	defer bctx.mtx.Unlock()
 
 	bctx.txsCnt += d
-	if isEVMTx {
-		bctx.evmTxsCnt += d
-	}
 }
 
 func (bctx *BlockContext) GetValUpdates() abcitypes.ValidatorUpdates {
@@ -309,7 +297,6 @@ func (bctx *BlockContext) MarshalJSON() ([]byte, error) {
 		BlockGasUsed   int64                       `json:"blockGasUsed"`
 		FeeSum         *uint256.Int                `json:"feeSum"`
 		TxsCnt         int                         `json:"txsCnt"`
-		EVMTxsCnt      int                         `json:"evmTxsCnt"`
 		AppHash        []byte                      `json:"appHash"`
 	}{
 		BlockInfo:      bctx.blockInfo,
@@ -318,7 +305,6 @@ func (bctx *BlockContext) MarshalJSON() ([]byte, error) {
 		BlockGasUsed:   bctx.GetBlockGasUsed(),
 		FeeSum:         bctx.feeSum,
 		TxsCnt:         bctx.txsCnt,
-		EVMTxsCnt:      bctx.evmTxsCnt,
 		AppHash:        bctx.appHash,
 	}
 
@@ -336,7 +322,6 @@ func (bctx *BlockContext) UnmarshalJSON(bz []byte) error {
 		BlockGasUsed   int64                       `json:"blockGasUsed"`
 		FeeSum         *uint256.Int                `json:"feeSum"`
 		TxsCnt         int                         `json:"txsCnt"`
-		EVMTxsCnt      int                         `json:"evmTxsCnt"`
 		AppHash        []byte                      `json:"appHash"`
 	}{}
 
@@ -349,7 +334,6 @@ func (bctx *BlockContext) UnmarshalJSON(bz []byte) error {
 	bctx.blockGasPool = new(ethcore.GasPool).AddGas(uint64(bctx.blockGasLimit - _bctx.BlockGasUsed))
 	bctx.feeSum = _bctx.FeeSum
 	bctx.txsCnt = _bctx.TxsCnt
-	bctx.evmTxsCnt = _bctx.EVMTxsCnt
 	bctx.appHash = _bctx.AppHash
 	return nil
 }

--- a/ctrlers/types/gov_params_test.go
+++ b/ctrlers/types/gov_params_test.go
@@ -1,7 +1,6 @@
 package types
 
 import (
-	"fmt"
 	"github.com/beatoz/beatoz-go/libs/jsonx"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
@@ -27,8 +26,6 @@ func Test_JsonCodec(t *testing.T) {
 	govParams := DefaultGovParams()
 	jz, err := jsonx.MarshalIndent(govParams, "", "  ")
 	require.NoError(t, err)
-
-	fmt.Println(string(jz))
 
 	govParams2 := &GovParams{}
 	err = jsonx.Unmarshal(jz, govParams2)

--- a/ctrlers/types/trx_ctx.go
+++ b/ctrlers/types/trx_ctx.go
@@ -86,16 +86,19 @@ func NewTrxContext(txbz []byte, bctx *BlockContext, exec bool) (*TrxContext, xer
 	if txctx.Sender == nil {
 		return nil, xerrors.ErrNotFoundAccount.Wrapf("sender address: %v", tx.From)
 	}
-	// RG-91:  Also find the account object with the destination address 0x0.
-	toAddr := tx.To
+
+	// RG-91: Find the account object with the destination address 0x0.
+	toAddr := txctx.Tx.To
 	if toAddr == nil {
 		// `toAddr` may be `nil` when the tx type is `TRX_CONTRACT`.
 		toAddr = types.ZeroAddress()
 	}
+
 	txctx.Receiver = txctx.BlockContext.AcctHandler.FindOrNewAccount(toAddr, txctx.Exec)
 	if txctx.Receiver == nil {
-		return nil, xerrors.ErrNotFoundAccount.Wrapf("receiver address: %v", tx.To)
+		return nil, xerrors.ErrNotFoundAccount.Wrapf("receiver address: %v", toAddr)
 	}
+
 	if payerAddr != nil {
 		txctx.Payer = txctx.BlockContext.AcctHandler.FindAccount(payerAddr, txctx.Exec)
 		if txctx.Payer == nil {

--- a/ctrlers/types/trx_ctx_test.go
+++ b/ctrlers/types/trx_ctx_test.go
@@ -85,6 +85,7 @@ func Test_NewTrxContext(t *testing.T) {
 
 	//
 	// To nil address (not contract transaction)
+	// todo: move this case to trx_test.go
 	tx = web3.NewTrxTransfer(w0.Address(), nil, 0, govMock.MinTrxGas(), govMock.GasPrice(), uint256.NewInt(1000))
 	_, _, _ = w0.SignTrxRLP(tx, chainId)
 	txctx, xerr = newTrxCtx(tx, 1)
@@ -100,7 +101,8 @@ func Test_NewTrxContext(t *testing.T) {
 	require.Equal(t, txctx.Sender.Address, w0.Address())
 	require.NotNil(t, txctx.Receiver)
 	require.Equal(t, txctx.Receiver.Address, types.ZeroAddress())
-
+	require.NotNil(t, txctx.Payer)
+	require.Equal(t, txctx.Payer.Address, w0.Address())
 	//
 	// To Zero Address
 	tx = web3.NewTrxTransfer(w0.Address(), types.ZeroAddress(), 0, govMock.MinTrxGas(), govMock.GasPrice(), uint256.NewInt(1000))
@@ -111,6 +113,8 @@ func Test_NewTrxContext(t *testing.T) {
 	require.Equal(t, txctx.Sender.Address, w0.Address())
 	require.NotNil(t, txctx.Receiver)
 	require.Equal(t, txctx.Receiver.Address, types.ZeroAddress())
+	require.NotNil(t, txctx.Payer)
+	require.Equal(t, txctx.Payer.Address, w0.Address())
 
 	//
 	// Success

--- a/node/app.go
+++ b/node/app.go
@@ -443,7 +443,7 @@ func (ctrler *BeatozApp) deliverTxSync(req abcitypes.RequestDeliverTx) abcitypes
 		}
 
 	}
-	ctrler.currBlockCtx.AddTxsCnt(1, txctx.IsHandledByEVM())
+	ctrler.currBlockCtx.AddTxsCnt(1)
 
 	xerr = ctrler.txExecutor.ExecuteSync(txctx)
 	if xerr != nil {
@@ -525,7 +525,7 @@ func (ctrler *BeatozApp) DeliverTx(req abcitypes.RequestDeliverTx) abcitypes.Res
 				}
 			}
 
-			ctrler.currBlockCtx.AddTxsCnt(1, txctx.IsHandledByEVM())
+			ctrler.currBlockCtx.AddTxsCnt(1)
 			return txctx, nil
 		},
 	)

--- a/node/trx_executor.go
+++ b/node/trx_executor.go
@@ -64,7 +64,6 @@ func commonValidation(ctx *ctrlertypes.TrxContext) xerrors.XError {
 }
 
 func validateTrx(ctx *ctrlertypes.TrxContext) xerrors.XError {
-
 	//
 	// tx validation
 	if xerr := commonValidation(ctx); xerr != nil {

--- a/node/trx_executor_test.go
+++ b/node/trx_executor_test.go
@@ -77,17 +77,21 @@ func Test_BlockGasLimit(t *testing.T) {
 	require.Equal(t, blockGasLimit, bctx.GetBlockGasLimit())
 	require.Equal(t, blockGasUsed, bctx.GetBlockGasUsed())
 
+	nonce := int64(0)
 	for {
 		rnGas := rand.Int64N(100_000) + govMock.MinTrxGas()
-		tx := web3.NewTrxTransfer(w0.Address(), w1.Address(), 0, rnGas, govMock.GasPrice(), uint256.NewInt(1))
+		tx := web3.NewTrxTransfer(w0.Address(), w1.Address(), nonce, rnGas, govMock.GasPrice(), uint256.NewInt(1))
 		_, _, xerr := w0.SignTrxRLP(tx, chainId)
 		require.NoError(t, xerr)
 
 		txctx, xerr := mocks.MakeTrxCtxWithTrxBctx(tx, bctx, true)
 		require.NoError(t, xerr)
 
+		require.NoError(t, validateTrx(txctx))
 		require.NoError(t, runTrx(txctx))
 		require.Equal(t, rnGas, txctx.GasUsed)
+
+		nonce++
 
 		blockGasUsed += rnGas
 
@@ -121,15 +125,18 @@ func Test_BlockGasLimit(t *testing.T) {
 		if blockGasUsed+rnGas >= lower {
 			break
 		}
-		tx := web3.NewTrxTransfer(w0.Address(), w1.Address(), 0, rnGas, govMock.GasPrice(), uint256.NewInt(1))
+		tx := web3.NewTrxTransfer(w0.Address(), w1.Address(), nonce, rnGas, govMock.GasPrice(), uint256.NewInt(1))
 		_, _, xerr := w0.SignTrxRLP(tx, chainId)
 		require.NoError(t, xerr)
 
 		txctx, xerr := mocks.MakeTrxCtxWithTrxBctx(tx, bctx, true)
 		require.NoError(t, xerr)
 
+		require.NoError(t, validateTrx(txctx))
 		require.NoError(t, runTrx(txctx))
 		require.Equal(t, rnGas, txctx.GasUsed)
+
+		nonce++
 
 		blockGasUsed += rnGas
 

--- a/test/4_transfer_test.go
+++ b/test/4_transfer_test.go
@@ -21,7 +21,7 @@ import (
 	"time"
 )
 
-func TestTransfer_NonceSequence(t *testing.T) {
+func TestTransfer_WrongAppHash(t *testing.T) {
 	bzweb3 := randBeatozWeb3()
 
 	w := randCommonWallet()
@@ -169,8 +169,6 @@ func TestTransferCommit_Bulk(t *testing.T) {
 	}
 	require.Greater(t, senderCnt, 0)
 
-	//// 최대 100 개 까지 계정 생성하여 리시버로 사용.
-	//// 100 개 이상이면 이미 있는 계정 사용.
 	for i := len(allAcctObjs); i < 100; i++ {
 		newAcctTestObj := newAcctObj(web3.NewWallet(defaultRpcNode.Pass))
 		require.NoError(t, saveWallet(newAcctTestObj.w))

--- a/test/helper_utils.go
+++ b/test/helper_utils.go
@@ -98,13 +98,19 @@ func prepareTest(_peers []*PeerMock) {
 
 	for _, peer := range _peers {
 		w := peer.PrivValWallet()
-		ret, _ := sender.TransferCommit(w.Address(), defGas, defGasPrice, btztypes.ToGrans(10_000_000), bzweb3)
-		if ret.CheckTx.Code != xerrors.ErrCodeSuccess {
-			panic(ret.CheckTx.Code)
+		//ret, _ := sender.TransferCommit(w.Address(), defGas, defGasPrice, btztypes.ToGrans(10_000_000), bzweb3)
+		//if ret.CheckTx.Code != xerrors.ErrCodeSuccess {
+		//	panic(ret.CheckTx.Code)
+		//}
+		//if ret.DeliverTx.Code != xerrors.ErrCodeSuccess {
+		//	panic(ret.DeliverTx.Code)
+		//}
+
+		ret, _ := sender.TransferSync(w.Address(), defGas, defGasPrice, btztypes.ToGrans(10_000_000), bzweb3)
+		if ret.Code != xerrors.ErrCodeSuccess {
+			panic(ret.Code)
 		}
-		if ret.DeliverTx.Code != xerrors.ErrCodeSuccess {
-			panic(ret.DeliverTx.Code)
-		}
+
 		sender.AddNonce()
 	}
 


### PR DESCRIPTION
This PR addresses a nondeterminism issue caused by premature account state mutations during parallel transaction context creation.

### 🐛 Problem
During parallel creation of `TrxContext`, the `TrxContext.Receiver` is resolved via `FindOrNewAccount`.  
If the account does not exist, it was previously created and **immediately written** into `AcctCtrler.acctState`.

Since multiple transactions could trigger this concurrently, the **order of account creation and writes** could differ across nodes — breaking determinism in a consensus-sensitive path.

### ✅ Solution
- Changed `FindOrNewAccount` to avoid writing newly created accounts into `acctState` immediately.
- Instead, newly created accounts are **held in memory** and only written to `acctState` **when actually modified**, during a **sequential execution phase**.
- This eliminates any nondeterministic side effects during `Receiver` resolution.

### 🔍 Impact
- Ensures deterministic behavior by **removing state mutation from a parallel phase**.
- `TrxContext.Receiver` resolution is now **free from side effects**, making system behavior easier to reason about.
- Fixes a subtle bug that could lead to consensus divergence in certain edge cases.

---

Please review the updated `FindOrNewAccount` logic and corresponding test coverage.
