### PR TITLE
Refactor controller and fix contract account code query behavior

### DIFF
--- a/ctrlers/supply/ctrler_mint.go
+++ b/ctrlers/supply/ctrler_mint.go
@@ -179,6 +179,9 @@ func heightYears(height int64, intval int32) fxnum.FxNum {
 	return scaledHeight(height*int64(intval), ctrlertypes.YearSeconds)
 }
 
+// Sd calculates the additional issuance amount based on the current supply and the inflation rate.
+// When FxNum uses `robaho/fixed` package, it supports only up to 7 decimal places.
+// Therefore, you must always use the shopspring/decimal package for final quantity calculations.
 func Sd(scaledHeight fxnum.FxNum, lastSupply, smax *uint256.Int, lambda int32, wa fxnum.FxNum) decimal.Decimal {
 	return decimalSd(scaledHeight, lastSupply, smax, lambda, wa)
 }

--- a/ctrlers/supply/ctrler_mint.go
+++ b/ctrlers/supply/ctrler_mint.go
@@ -176,7 +176,13 @@ func scaledHeight(height, base int64) fxnum.FxNum {
 }
 
 func heightYears(height int64, intval int32) fxnum.FxNum {
-	return scaledHeight(height*int64(intval), ctrlertypes.YearSeconds)
+	// Previously returned block height scaled to years
+	// using block interval since genesis.
+	//  `return scaledHeight(height*int64(intval), ctrlertypes.YearSeconds)`
+	// However, annual reward variance became too large.
+	// Although functional, such variance may harm validator stability.
+	// Now always returns a fixed value instead.
+	return fxnum.FromInt(1)
 }
 
 // Sd calculates the additional issuance amount based on the current supply and the inflation rate.

--- a/ctrlers/vm/evm/ctrler.go
+++ b/ctrlers/vm/evm/ctrler.go
@@ -3,6 +3,11 @@ package evm
 import (
 	"encoding/hex"
 	"fmt"
+	"math/big"
+	"strconv"
+	"strings"
+	"sync"
+
 	ctrlertypes "github.com/beatoz/beatoz-go/ctrlers/types"
 	"github.com/beatoz/beatoz-go/types"
 	"github.com/beatoz/beatoz-go/types/bytes"
@@ -19,10 +24,6 @@ import (
 	abcitypes "github.com/tendermint/tendermint/abci/types"
 	tmlog "github.com/tendermint/tendermint/libs/log"
 	tmdb "github.com/tendermint/tm-db"
-	"math/big"
-	"strconv"
-	"strings"
-	"sync"
 )
 
 var (
@@ -407,8 +408,8 @@ func (ctrler *EVMCtrler) Close() xerrors.XError {
 
 // MemStateAt returns the ledger of EVM and AcctCtrler with the state values at the `height`.
 // THIS LEDGER MUST BE NOT COMMITED.
-// MemStateAt is called from `QueryCode` and `callVM`.
-// When it is called from `QueryCode`, this ledger is only read (not updated).
+// MemStateAt is called from `GetCode` and `callVM`.
+// When it is called from `GetCode`, this ledger is only read (not updated).
 // In this case, the ledger can be immutable.
 // When it is called from `callVM`, this ledger may be updated.
 // In this case, the ledger should not be immutable.

--- a/ctrlers/vm/evm/erc20_test.go
+++ b/ctrlers/vm/evm/erc20_test.go
@@ -7,10 +7,10 @@ import (
 	"io/ioutil"
 	"math/big"
 	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
+	cfg "github.com/beatoz/beatoz-go/cmd/config"
 	"github.com/beatoz/beatoz-go/ctrlers/mocks"
 	govmock "github.com/beatoz/beatoz-go/ctrlers/mocks/gov"
 	ctrlertypes "github.com/beatoz/beatoz-go/ctrlers/types"
@@ -32,7 +32,7 @@ import (
 var (
 	govMock     = govmock.NewGovHandlerMock(ctrlertypes.DefaultGovParams())
 	acctHandler acctHandlerMock
-	dbPath      = filepath.Join(os.TempDir(), "beatoz-evm-test")
+	btzCfg      *cfg.Config
 )
 
 var (
@@ -49,6 +49,11 @@ type TruffleBuild struct {
 }
 
 func init() {
+	btzCfg = cfg.DefaultConfig()
+	btzCfg.ChainID = "0xDEA8D3"
+	btzCfg.RootDir = os.TempDir()
+	btzCfg.DBPath = "evm-test-db"
+
 	// initialize acctHandler
 	acctHandler.origin = true
 	acctHandler.walletsMap = make(map[string]*web3.Wallet)
@@ -78,8 +83,9 @@ func init() {
 }
 
 func Test_ValidateTrx(t *testing.T) {
-	os.RemoveAll(dbPath)
-	ctrler := NewEVMCtrler(dbPath, &acctHandler, tmlog.NewNopLogger() /*tmlog.NewTMLogger(tmlog.NewSyncWriter(os.Stdout))*/)
+	os.RemoveAll(btzCfg.DBDir())
+
+	ctrler := NewEVMCtrler(btzCfg, &acctHandler, tmlog.NewNopLogger() /*tmlog.NewTMLogger(tmlog.NewSyncWriter(os.Stdout))*/)
 
 	// deploy tx	: address == zero, code == nil
 	// normal tx	: address != zero, code != nil
@@ -123,8 +129,8 @@ func Test_ValidateTrx(t *testing.T) {
 }
 
 func Test_Deploy(t *testing.T) {
-	os.RemoveAll(dbPath)
-	erc20EVM = NewEVMCtrler(dbPath, &acctHandler, tmlog.NewNopLogger() /*tmlog.NewTMLogger(tmlog.NewSyncWriter(os.Stdout))*/)
+	os.RemoveAll(btzCfg.DBDir())
+	erc20EVM = NewEVMCtrler(btzCfg, &acctHandler, tmlog.NewNopLogger() /*tmlog.NewTMLogger(tmlog.NewSyncWriter(os.Stdout))*/)
 
 	deployInput, err := abiERC20Contract.Pack("", "TokenOnBeatoz", "TOR")
 	require.NoError(t, err)
@@ -208,7 +214,7 @@ func Test_Transfer(t *testing.T) {
 	xerr = erc20EVM.Close()
 	require.NoError(t, xerr)
 
-	erc20EVM = NewEVMCtrler(dbPath, &acctHandler, tmlog.NewNopLogger())
+	erc20EVM = NewEVMCtrler(btzCfg, &acctHandler, tmlog.NewNopLogger())
 	state, xerr = erc20EVM.MemStateAt(erc20EVM.lastBlockHeight)
 	require.NoError(t, xerr)
 

--- a/ctrlers/vm/evm/erc20_test.go
+++ b/ctrlers/vm/evm/erc20_test.go
@@ -4,6 +4,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
 	"github.com/beatoz/beatoz-go/ctrlers/mocks"
 	govmock "github.com/beatoz/beatoz-go/ctrlers/mocks/gov"
 	ctrlertypes "github.com/beatoz/beatoz-go/ctrlers/types"
@@ -20,12 +27,6 @@ import (
 	"github.com/stretchr/testify/require"
 	abcitypes "github.com/tendermint/tendermint/abci/types"
 	tmlog "github.com/tendermint/tendermint/libs/log"
-	"io/ioutil"
-	"math/big"
-	"os"
-	"path/filepath"
-	"testing"
-	"time"
 )
 
 var (
@@ -140,7 +141,7 @@ func Test_Deploy(t *testing.T) {
 	fmt.Println("TestDeploy", "used gas", txctx.GasUsed)
 	fmt.Println("TestDeploy", "Commit block", height)
 
-	bzCode, xerr := erc20EVM.QueryCode(erc20ContAddr, height)
+	bzCode, xerr := erc20EVM.GetCode(erc20ContAddr, height)
 	require.NoError(t, xerr)
 	require.Equal(t, []byte(erc20BuildInfo.DeployedBytecode), []byte(bzCode))
 

--- a/ctrlers/vm/evm/fallback_test.go
+++ b/ctrlers/vm/evm/fallback_test.go
@@ -4,6 +4,12 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
 	ctrlertypes "github.com/beatoz/beatoz-go/ctrlers/types"
 	"github.com/beatoz/beatoz-go/libs/jsonx"
 	"github.com/beatoz/beatoz-go/types"
@@ -16,11 +22,6 @@ import (
 	abcitypes "github.com/tendermint/tendermint/abci/types"
 	tmlog "github.com/tendermint/tendermint/libs/log"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
-	"io/ioutil"
-	"os"
-	"strings"
-	"testing"
-	"time"
 )
 
 var (
@@ -41,8 +42,8 @@ func init() {
 }
 
 func Test_Fallback(t *testing.T) {
-	os.RemoveAll(dbPath)
-	fallbackEVM = NewEVMCtrler(dbPath, &acctHandler, tmlog.NewNopLogger() /*tmlog.NewTMLogger(tmlog.NewSyncWriter(os.Stdout))*/)
+	os.RemoveAll(btzCfg.DBDir())
+	fallbackEVM = NewEVMCtrler(btzCfg, &acctHandler, tmlog.NewNopLogger() /*tmlog.NewTMLogger(tmlog.NewSyncWriter(os.Stdout))*/)
 
 	//
 	// deploy

--- a/ctrlers/vm/evm/query.go
+++ b/ctrlers/vm/evm/query.go
@@ -2,6 +2,10 @@ package evm
 
 import (
 	"fmt"
+	"math"
+	"math/big"
+	"time"
+
 	ctrlertypes "github.com/beatoz/beatoz-go/ctrlers/types"
 	"github.com/beatoz/beatoz-go/libs/jsonx"
 	"github.com/beatoz/beatoz-go/types"
@@ -12,9 +16,6 @@ import (
 	ethcoretypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	abcitypes "github.com/tendermint/tendermint/abci/types"
-	"math"
-	"math/big"
-	"time"
 )
 
 func (ctrler *EVMCtrler) Query(req abcitypes.RequestQuery, opts ...ctrlertypes.Option) ([]byte, xerrors.XError) {
@@ -54,7 +55,7 @@ func (ctrler *EVMCtrler) Query(req abcitypes.RequestQuery, opts ...ctrlertypes.O
 	return retbz, nil
 }
 
-func (ctrler *EVMCtrler) QueryCode(addr types.Address, height int64) ([]byte, xerrors.XError) {
+func (ctrler *EVMCtrler) GetCode(addr types.Address, height int64) ([]byte, xerrors.XError) {
 	state, xerr := ctrler.MemStateAt(height)
 	if xerr != nil {
 		return nil, xerr

--- a/ctrlers/vpower/weight_fxnum.go
+++ b/ctrlers/vpower/weight_fxnum.go
@@ -1,5 +1,10 @@
 package vpower
 
+//
+// The `libs/fxnum` package is a wrapper around `robaho/fixed` and `shopspring/decimal`.
+// When built with the '-tags decimal' build tag, it uses `shopspring/decimal`; otherwise (by default), it uses `robaho/fixed`.
+//
+
 import (
 	"github.com/beatoz/beatoz-go/libs/fxnum"
 	"github.com/beatoz/beatoz-go/types"

--- a/node/app.go
+++ b/node/app.go
@@ -80,7 +80,7 @@ func NewBeatozApp(config *cfg.Config, logger log.Logger) *BeatozApp {
 		panic(err)
 	}
 
-	vmCtrler := evm.NewEVMCtrler(config.DBDir(), acctCtrler, logger)
+	vmCtrler := evm.NewEVMCtrler(config, acctCtrler, logger)
 
 	txExecutor := NewTrxExecutor(logger)
 


### PR DESCRIPTION
### Changes made in this pull request:

- Updated `NewEVMCtrler` to retrieve the chain ID from the configuration, ensuring flexibility and alignment with configuration properties.
- `heightYears` always returns 1 to limit annual reward variance.
- Fixed the query for contract accounts to return deployed code instead of a code hash, addressing inconsistency in contract-related queries.
- Updated relevant tests to reflect the changes made and to ensure correctness.
- Improved code readability by adding comments. 

### Checklist:

- [ ] I have tested the changes locally.
- [ ] I have added necessary documentation (if applicable).
- [ ] Code builds and passes all tests without errors.