### PR TITLE
Prevent EndBlock Panic on Invalid Transaction Context Creation

### DIFF
--- a/node/app.go
+++ b/node/app.go
@@ -490,6 +490,7 @@ func (ctrler *BeatozApp) DeliverTx(req abcitypes.RequestDeliverTx) abcitypes.Res
 	// Parallel tx processing.
 	// Just request to create `TrxContext` with `req RequestDeliverTx`.
 	// The executions for this `req RequestDeliverTx` will be done in `EncBlockSync`
+	ctrler.currBlockCtx.AddTxsCnt(1)
 	ctrler.txExecutor.Add(
 		&req,
 		func(req *abcitypes.RequestDeliverTx, idx int) (*ctrlertypes.TrxContext, *abcitypes.ResponseDeliverTx) {
@@ -506,7 +507,7 @@ func (ctrler *BeatozApp) DeliverTx(req abcitypes.RequestDeliverTx) abcitypes.Res
 				}
 			}
 
-			ctrler.currBlockCtx.AddTxsCnt(1)
+			txctx.TxIdx = idx
 			return txctx, nil
 		},
 	)
@@ -629,8 +630,9 @@ func (ctrler *BeatozApp) EndBlock(req abcitypes.RequestEndBlock) abcitypes.Respo
 		ctrler.txExecutor.TrxPreparer.Wait()
 		// for debugging
 		if ctrler.txExecutor.TrxPreparer.resultCount() != ctrler.currBlockCtx.TxsCnt() {
-			panic(fmt.Sprintf("error: len(client.deliverTxReqs)(%v) != txs count in block(%v)",
-				ctrler.txExecutor.TrxPreparer.resultCount(), ctrler.currBlockCtx.TxsCnt()))
+			ctrler.logger.Error("transaction count mismatch",
+				"prepared", ctrler.txExecutor.TrxPreparer.resultCount(),
+				"blockTxs", ctrler.currBlockCtx.TxsCnt())
 		}
 
 		// Execute every transaction in its own `TrxContext` sequentially

--- a/node/app_test.go
+++ b/node/app_test.go
@@ -20,6 +20,61 @@ import (
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 )
 
+func newTestBeatozApp(t *testing.T, wallets []*web3.Wallet) (*BeatozApp, *beatozLocalClient, func()) {
+	t.Helper()
+
+	appState := genesis.GenesisAppState{
+		AssetHolders: make([]*genesis.GenesisAssetHolder, len(wallets)),
+		GovParams:    types.DefaultGovParams(),
+	}
+	for i, w := range wallets {
+		appState.AssetHolders[i] = &genesis.GenesisAssetHolder{
+			Address: w.Address(),
+			Balance: types2.ToGrans(1_000),
+		}
+	}
+	jz, err := jsonx.Marshal(appState)
+	require.NoError(t, err)
+
+	btxcfg := config.DefaultConfig("1234")
+	btxcfg.SetRoot(filepath.Join(t.TempDir(), "beatoz-test"))
+
+	btzApp := NewBeatozApp(btxcfg, log.NewNopLogger())
+	btzClient := NewBeatozLocalClient(&tmsync.Mutex{}, btzApp)
+	btzClient.SetResponseCallback(func(*abcitypes.Request, *abcitypes.Response) {})
+	btzApp.SetLocalClient(btzClient)
+
+	btzApp.Info(abcitypes.RequestInfo{})
+	btzApp.InitChain(abcitypes.RequestInitChain{
+		ChainId: btxcfg.ChainIdHex(),
+		ConsensusParams: &abcitypes.ConsensusParams{
+			Block: &abcitypes.BlockParams{
+				MaxBytes: 22020096,
+				MaxGas:   36_000_000,
+			},
+		},
+		Validators: abcitypes.ValidatorUpdates{
+			abcitypes.UpdateValidator(wallets[0].GetPubKey(), 1_000_000, "secp256k1"),
+		},
+		AppStateBytes: jz,
+		InitialHeight: 1,
+	})
+	btzApp.Start()
+
+	btzApp.BeginBlock(abcitypes.RequestBeginBlock{
+		Header: tmproto.Header{Height: 1, ChainID: btxcfg.ChainIdHex()},
+	})
+	btzApp.EndBlock(abcitypes.RequestEndBlock{Height: 1})
+	btzApp.Commit()
+
+	cleanup := func() {
+		btzApp.Stop()
+		os.RemoveAll(btxcfg.RootDir)
+		types.InitSigner(chainId)
+	}
+	return btzApp, btzClient.(*beatozLocalClient), cleanup
+}
+
 func Test_InitChain(t *testing.T) {
 	// max total supply is less than initial total supply
 	req := abcitypes.RequestInitChain{
@@ -58,6 +113,112 @@ func Test_InitChain(t *testing.T) {
 	_, genTotalSupply, err := checkRequestInitChain(req)
 	require.NoError(t, err)
 	require.Equal(t, "6000000000000000000", genTotalSupply.Dec())
+}
+
+func Test_EndBlock_NoChainHalt(t *testing.T) {
+	testCases := []struct {
+		name  string
+		build func(t *testing.T, app *BeatozApp, chainID string, wallets []*web3.Wallet) []byte
+	}{
+		{
+			name: "wrong_gas_price",
+			build: func(t *testing.T, app *BeatozApp, chainID string, wallets []*web3.Wallet) []byte {
+				gasPrice := new(uint256.Int).Add(app.govCtrler.GasPrice(), uint256.NewInt(1))
+				tx := web3.NewTrxTransfer(
+					wallets[0].Address(), types2.RandAddress(),
+					wallets[0].GetNonce(),
+					app.govCtrler.MinTrxGas(), gasPrice,
+					uint256.NewInt(1),
+				)
+				_, _, err := wallets[0].SignTrxRLP(tx, chainID)
+				require.NoError(t, err)
+				txbz, err := tx.Encode()
+				require.NoError(t, err)
+				return txbz
+			},
+		},
+		{
+			name: "small_gas",
+			build: func(t *testing.T, app *BeatozApp, chainID string, wallets []*web3.Wallet) []byte {
+				tx := web3.NewTrxTransfer(
+					wallets[0].Address(), types2.RandAddress(),
+					wallets[0].GetNonce(),
+					app.govCtrler.MinTrxGas()-1, app.govCtrler.GasPrice(),
+					uint256.NewInt(1),
+				)
+				_, _, err := wallets[0].SignTrxRLP(tx, chainID)
+				require.NoError(t, err)
+				txbz, err := tx.Encode()
+				require.NoError(t, err)
+				return txbz
+			},
+		},
+		{
+			name: "wrong_signature",
+			build: func(t *testing.T, app *BeatozApp, chainID string, wallets []*web3.Wallet) []byte {
+				tx := web3.NewTrxTransfer(
+					wallets[0].Address(), types2.RandAddress(),
+					wallets[0].GetNonce(),
+					app.govCtrler.MinTrxGas(), app.govCtrler.GasPrice(),
+					uint256.NewInt(1),
+				)
+				_, _, err := wallets[1].SignTrxRLP(tx, chainID)
+				require.NoError(t, err)
+				txbz, err := tx.Encode()
+				require.NoError(t, err)
+				return txbz
+			},
+		},
+		{
+			name: "sender_not_found",
+			build: func(t *testing.T, app *BeatozApp, chainID string, wallets []*web3.Wallet) []byte {
+				unknownSender := web3.NewWallet(nil)
+				tx := web3.NewTrxTransfer(
+					unknownSender.Address(), types2.RandAddress(),
+					unknownSender.GetNonce(),
+					app.govCtrler.MinTrxGas(), app.govCtrler.GasPrice(),
+					uint256.NewInt(1),
+				)
+				_, _, err := unknownSender.SignTrxRLP(tx, chainID)
+				require.NoError(t, err)
+				txbz, err := tx.Encode()
+				require.NoError(t, err)
+				return txbz
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			wallets := []*web3.Wallet{web3.NewWallet(nil), web3.NewWallet(nil)}
+			btzApp, btzClient, cleanup := newTestBeatozApp(t, wallets)
+			defer cleanup()
+
+			var deliverTxResp *abcitypes.ResponseDeliverTx
+			btzClient.SetResponseCallback(func(req *abcitypes.Request, resp *abcitypes.Response) {
+				if r := resp.GetDeliverTx(); r != nil {
+					deliverTxResp = r
+				}
+			})
+
+			chainID := btzApp.lastBlockCtx.ChainID()
+			txbz := tc.build(t, btzApp, chainID, wallets)
+
+			btzApp.BeginBlock(abcitypes.RequestBeginBlock{
+				Header: tmproto.Header{Height: 2, ChainID: chainID},
+			})
+			btzApp.DeliverTx(abcitypes.RequestDeliverTx{Tx: txbz})
+			require.Equal(t, 1, btzApp.currBlockCtx.TxsCnt())
+
+			require.NotPanics(t, func() {
+				btzApp.EndBlock(abcitypes.RequestEndBlock{Height: 2})
+			})
+			require.NotNil(t, deliverTxResp)
+			require.NotEqual(t, abcitypes.CodeTypeOK, deliverTxResp.Code)
+
+			btzApp.Commit()
+		})
+	}
 }
 
 func Benchmark_TxLifeCycle(b *testing.B) {


### PR DESCRIPTION
# Prevent EndBlock Panic on Invalid Transaction Context Creation

## Summary

This PR prevents `EndBlock` from panicking when a block contains transactions that fail during `NewTrxContext` creation.

Previously, the block tx count was increased only after `NewTrxContext` succeeded. As a result, invalid transactions could make `TrxPreparer.resultCount()` differ from `currBlockCtx.TxsCnt()`, causing an `EndBlock` panic and possible chain halt.

The specific issue addressed by this PR is tracked in [BG-590](https://beatoz.atlassian.net/jira/software/projects/BG/boards/82?selectedIssue=BG-590).
## Changes

- Count delivered transactions when they are enqueued, regardless of validity.
- Keep `TxIdx` assignment for successfully created `TrxContext` values.
- Replace the `EndBlock` tx count mismatch panic with an error log.
- Add regression tests to ensure invalid transactions do not halt block processing.

## Changed Files

- `node/app.go`: updates tx count accounting and removes the panic path.
- `node/app_test.go`: adds no-panic regression coverage for invalid tx cases.

## Test

```bash
go test ./node
```

Result:

```text
ok  	github.com/beatoz/beatoz-go/node	2.747s
```
