### PR TITLE
Prevent Transaction Panic on Invalid Signature Length

### DIFF
--- a/ctrlers/types/signer.go
+++ b/ctrlers/types/signer.go
@@ -6,6 +6,7 @@ import (
 	"github.com/beatoz/beatoz-go/types"
 	"github.com/beatoz/beatoz-go/types/bytes"
 	"github.com/beatoz/beatoz-go/types/xerrors"
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/holiman/uint256"
 )
@@ -40,6 +41,9 @@ func getSigner(v byte) (ISigner, xerrors.XError) {
 }
 
 func VerifyTrxRLP(tx *Trx) (types.Address, bytes.HexBytes, xerrors.XError) {
+	if len(tx.Sig) != ethcrypto.SignatureLength {
+		return nil, nil, xerrors.ErrInvalidTrxSig.Wrapf("sig length is invalid - expected: %d, actual: %d", ethcrypto.SignatureLength, len(tx.Sig))
+	}
 	signer, xerr := getSigner(tx.Sig[64])
 	if xerr != nil {
 		return nil, nil, xerr
@@ -48,6 +52,9 @@ func VerifyTrxRLP(tx *Trx) (types.Address, bytes.HexBytes, xerrors.XError) {
 }
 
 func VerifyPayerTrxRLP(tx *Trx) (types.Address, bytes.HexBytes, xerrors.XError) {
+	if len(tx.PayerSig) != ethcrypto.SignatureLength {
+		return nil, nil, xerrors.ErrInvalidTrxSig.Wrapf("payer sig length is invalid - expected: %d, actual: %d", ethcrypto.SignatureLength, len(tx.PayerSig))
+	}
 	signer, xerr := getSigner(tx.PayerSig[64])
 	if xerr != nil {
 		return nil, nil, xerr

--- a/ctrlers/types/signer_test.go
+++ b/ctrlers/types/signer_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/beatoz/beatoz-go/types"
 	"github.com/beatoz/beatoz-go/types/bytes"
 	"github.com/beatoz/beatoz-go/types/crypto"
+	"github.com/beatoz/beatoz-go/types/xerrors"
 	"github.com/beatoz/beatoz-sdk-go/web3"
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
@@ -17,6 +18,56 @@ import (
 
 func init() {
 	ctrtypes.InitSigner(chainId)
+}
+
+func TestVerifyTrxRLPInvalidSignature(t *testing.T) {
+	tests := []struct {
+		name string
+		sig  bytes.HexBytes
+	}{
+		{name: "nil", sig: nil},
+		{name: "one_byte", sig: bytes.HexBytes{0x01}},
+		{name: "sixty_four_bytes", sig: bytes.HexBytes(bytes.ZeroBytes(64))},
+		{name: "invalid_v", sig: bytes.HexBytes(append(bytes.ZeroBytes(64), 99))},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tx := &ctrtypes.Trx{Sig: tt.sig}
+			var xerr xerrors.XError
+
+			require.NotPanics(t, func() {
+				_, _, xerr = ctrtypes.VerifyTrxRLP(tx)
+			})
+			require.Error(t, xerr)
+			require.True(t, xerr.Contains(xerrors.ErrInvalidTrxSig), "unexpected error: %v", xerr)
+		})
+	}
+}
+
+func TestVerifyPayerTrxRLPInvalidSignature(t *testing.T) {
+	tests := []struct {
+		name string
+		sig  bytes.HexBytes
+	}{
+		{name: "nil", sig: nil},
+		{name: "one_byte", sig: bytes.HexBytes{0x01}},
+		{name: "sixty_four_bytes", sig: bytes.HexBytes(bytes.ZeroBytes(64))},
+		{name: "invalid_v", sig: bytes.HexBytes(append(bytes.ZeroBytes(64), 99))},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tx := &ctrtypes.Trx{PayerSig: tt.sig}
+			var xerr xerrors.XError
+
+			require.NotPanics(t, func() {
+				_, _, xerr = ctrtypes.VerifyPayerTrxRLP(tx)
+			})
+			require.Error(t, xerr)
+			require.True(t, xerr.Contains(xerrors.ErrInvalidTrxSig), "unexpected error: %v", xerr)
+		})
+	}
 }
 
 func TestSignerV0_Recover(t *testing.T) {

--- a/ctrlers/types/trx.go
+++ b/ctrlers/types/trx.go
@@ -7,6 +7,7 @@ import (
 	"github.com/beatoz/beatoz-go/types"
 	"github.com/beatoz/beatoz-go/types/bytes"
 	"github.com/beatoz/beatoz-go/types/xerrors"
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/holiman/uint256"
 	"google.golang.org/protobuf/proto"
@@ -359,14 +360,14 @@ func (tx *Trx) Validate() xerrors.XError {
 	if tx.Payload != nil && tx.Type != tx.Payload.Type() {
 		return xerrors.ErrInvalidTrxPayloadType
 	}
-	if tx.Sig == nil {
-		return xerrors.ErrInvalidTrxSig
+	if len(tx.Sig) != ethcrypto.SignatureLength {
+		return xerrors.ErrInvalidTrxSig.Wrapf("sig length is invalid - expected: %d, actual: %d", ethcrypto.SignatureLength, len(tx.Sig))
 	}
 	if tx.Payer != nil && len(tx.Payer) != types.AddrSize {
 		return xerrors.ErrInvalidAddress.Wrapf("payer(%v)'s addr is invalid", tx.Payer)
 	}
-	if tx.Payer != nil && tx.PayerSig == nil {
-		return xerrors.ErrInvalidTrxSig.Wrapf("payer(%v)'s sig is nil", tx.Payer)
+	if tx.Payer != nil && len(tx.PayerSig) != ethcrypto.SignatureLength {
+		return xerrors.ErrInvalidTrxSig.Wrapf("payer(%v)'s sig length is invalid - expected: %d, actual: %d", tx.Payer, ethcrypto.SignatureLength, len(tx.PayerSig))
 	}
 	return nil
 }

--- a/ctrlers/types/trx_test.go
+++ b/ctrlers/types/trx_test.go
@@ -44,6 +44,48 @@ func TestTrxEncode(t *testing.T) {
 	require.Equal(t, bzTx0, bzTx1)
 }
 
+func TestTrxValidateInvalidSignature(t *testing.T) {
+	validSig := bytes.HexBytes(bytes.ZeroBytes(65))
+	tests := []struct {
+		name     string
+		sig      bytes.HexBytes
+		payer    types.Address
+		payerSig bytes.HexBytes
+	}{
+		{name: "nil_sender_sig", sig: nil},
+		{name: "one_byte_sender_sig", sig: bytes.HexBytes{0x01}},
+		{name: "sixty_four_byte_sender_sig", sig: bytes.HexBytes(bytes.ZeroBytes(64))},
+		{name: "sixty_six_byte_sender_sig", sig: bytes.HexBytes(bytes.ZeroBytes(66))},
+		{name: "nil_payer_sig", sig: validSig, payer: types.RandAddress(), payerSig: nil},
+		{name: "one_byte_payer_sig", sig: validSig, payer: types.RandAddress(), payerSig: bytes.HexBytes{0x01}},
+		{name: "sixty_four_byte_payer_sig", sig: validSig, payer: types.RandAddress(), payerSig: bytes.HexBytes(bytes.ZeroBytes(64))},
+		{name: "sixty_six_byte_payer_sig", sig: validSig, payer: types.RandAddress(), payerSig: bytes.HexBytes(bytes.ZeroBytes(66))},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tx := &types2.Trx{
+				Version:  1,
+				Time:     time.Now().UnixNano(),
+				Nonce:    rand.Int63(),
+				From:     types.RandAddress(),
+				To:       types.RandAddress(),
+				Amount:   uint256.NewInt(0),
+				Gas:      rand.Int63(),
+				GasPrice: uint256.NewInt(rand.Uint64()),
+				Type:     types2.TRX_TRANSFER,
+				Sig:      tt.sig,
+				Payer:    tt.payer,
+				PayerSig: tt.payerSig,
+			}
+
+			xerr := tx.Validate()
+			require.Error(t, xerr)
+			require.True(t, xerr.Contains(xerrors.ErrInvalidTrxSig), "unexpected error: %v", xerr)
+		})
+	}
+}
+
 func TestTrxDecodeWithMaliciousPayload(t *testing.T) {
 	// The malicious users can exploit this by submitting a large number of TRX_TRANSFER and TRX_STAKING transactions,
 	// each with a large payload but under 1MB in size.


### PR DESCRIPTION
# Prevent Transaction Panic on Invalid Signature Length

## Summary

This PR prevents transaction validation and signature verification from panicking when a transaction contains an invalid sender or payer signature length.

Previously, `Trx.Validate()` only checked whether signatures were nil. As a result, short non-nil signatures could pass validation and later cause an index out of range panic when `VerifyTrxRLP()` or `VerifyPayerTrxRLP()` accessed the recovery id at byte index 64.

The specific issue addressed by this PR is tracked in [BG-593](https://beatoz.atlassian.net/jira/software/projects/BG/boards/82?selectedIssue=BG-593).


## Changes

- Validate sender signature length against the Ethereum signature length before accepting a transaction.
- Validate payer signature length when a payer is present.
- Add defensive signature length checks in `VerifyTrxRLP()` and `VerifyPayerTrxRLP()` before reading the recovery id.
- Add regression tests for nil, short, and malformed sender and payer signature cases.

## Changed Files

- `ctrlers/types/trx.go`: rejects transactions whose sender or payer signature length is not 65 bytes.
- `ctrlers/types/signer.go`: guards RLP signature verification against invalid signature lengths before indexing signature bytes.
- `ctrlers/types/trx_test.go`: adds validation coverage for invalid sender and payer signature lengths.
- `ctrlers/types/signer_test.go`: adds no-panic regression coverage for invalid signatures during sender and payer verification.

## Test

```bash
go test ./ctrlers/types
```

Result:

```text
ok  	github.com/beatoz/beatoz-go/ctrlers/types
```
