### PR TITLE
Validate Governance Parameter Proposals Before Applying

### DIFF
--- a/ctrlers/gov/1_proposal_test.go
+++ b/ctrlers/gov/1_proposal_test.go
@@ -134,6 +134,58 @@ func TestProposalDuplicate(t *testing.T) {
 	}
 }
 
+func TestInvalidGovParamsProposalValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*ctrlertypes.GovParamsProto)
+		wantMsg string
+	}{
+		{
+			name: "negative_max_validator_count",
+			mutate: func(v *ctrlertypes.GovParamsProto) {
+				v.MaxValidatorCnt = -1
+			},
+			wantMsg: "maxValidatorCnt",
+		},
+		{
+			name: "tx_fee_reward_rate_over_100",
+			mutate: func(v *ctrlertypes.GovParamsProto) {
+				v.TxFeeRewardRate = 200
+			},
+			wantMsg: "txFeeRewardRate",
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			newGovParams := &ctrlertypes.GovParams{}
+			newGovParams.SetValue(tt.mutate)
+			bzOpt, err := jsonx.Marshal(newGovParams)
+			require.NoError(t, err)
+
+			tx := web3.NewTrxProposal(
+				vpowMock.PickAddress(vpowMock.ValCnt-1),
+				types.ZeroAddress(),
+				int64(100+i),
+				defMinGas,
+				defGasPrice,
+				"invalid govparams proposal",
+				10,
+				govCtrler.MinVotingPeriodBlocks(),
+				10+govCtrler.MinVotingPeriodBlocks()+govCtrler.LazyApplyingBlocks(),
+				proposal.PROPOSAL_GOVPARAMS,
+				bzOpt,
+			)
+			require.NoError(t, signTrx(tx, vpowMock.PickAddress(vpowMock.ValCnt-1), config.ChainIdHex()))
+
+			xerr := runTrx(makeTrxCtx(tx, 1, true))
+			require.Error(t, xerr)
+			require.True(t, xerr.Contains(xerrors.ErrInvalidTrxPayloadParams), xerr)
+			require.Contains(t, xerr.Error(), tt.wantMsg)
+		})
+	}
+}
+
 func TestOverflowBlockHeight(t *testing.T) {
 	bzOpt, err := jsonx.Marshal(govParams0)
 	require.NoError(t, err)

--- a/ctrlers/gov/2_voting_test.go
+++ b/ctrlers/gov/2_voting_test.go
@@ -280,3 +280,43 @@ func TestApplyingProposal(t *testing.T) {
 	require.NotEqual(t, oriParams, govCtrler.GovParams)
 	require.True(t, govParams1.Equal(&govCtrler.GovParams))
 }
+
+func TestApplyInvalidGovParamsProposalRejected(t *testing.T) {
+	oriParams := govCtrler.GovParams
+	govCtrler.newGovParams = nil
+
+	invalidGovParams := &ctrlertypes.GovParams{}
+	invalidGovParams.SetValue(func(v *ctrlertypes.GovParamsProto) {
+		v.MaxValidatorCnt = -1
+	})
+	bzOpt, err := jsonx.Marshal(invalidGovParams)
+	require.NoError(t, err)
+
+	txHash := bytes.RandBytes(32)
+	applyHeight := int64(100)
+	prop := proposal.NewGovProposal(proposal.PROPOSAL_GOVPARAMS, txHash, 1, 1, 1, applyHeight)
+	prop.AddOption(bzOpt)
+	require.NotNil(t, prop.UpdateMajorOption())
+
+	frozenKey := v1.LedgerKeyFrozenProp(txHash)
+	require.NoError(t, govCtrler.govState.Set(frozenKey, prop, true))
+
+	bctx := &ctrlertypes.BlockContext{}
+	bctx.SetHeight(applyHeight)
+	evts, xerr := govCtrler.EndBlock(bctx)
+	require.NoError(t, xerr)
+	require.Nil(t, govCtrler.newGovParams)
+	require.True(t, oriParams.Equal(&govCtrler.GovParams))
+
+	require.Len(t, evts, 1)
+	require.Equal(t, "proposal", evts[0].Type)
+	require.Len(t, evts[0].Attributes, 1)
+	require.Equal(t, "rejected", string(evts[0].Attributes[0].Key))
+
+	_, _, xerr = govCtrler.Commit()
+	require.NoError(t, xerr)
+
+	frozenProp, xerr := govCtrler.govState.Get(frozenKey, false)
+	require.Equal(t, xerrors.ErrNotFoundResult, xerr)
+	require.Nil(t, frozenProp)
+}

--- a/ctrlers/gov/ctrler.go
+++ b/ctrlers/gov/ctrler.go
@@ -115,10 +115,14 @@ func (ctrler *GovCtrler) ValidateTrx(ctx *ctrlertypes.TrxContext) xerrors.XError
 		// check governance proposal consistency
 		if txpayload.OptType == proposal.PROPOSAL_GOVPARAMS {
 			//check options
-			checkGovParams := &ctrlertypes.GovParams{}
 			for _, option := range txpayload.Options {
+				checkGovParams := &ctrlertypes.GovParams{}
 				if err := jsonx.Unmarshal(option, checkGovParams); err != nil {
 					return xerrors.ErrInvalidTrxPayloadParams.Wrap(err)
+				}
+				ctrlertypes.MergeGovParams(&ctrler.GovParams, checkGovParams)
+				if xerr := checkGovParams.ValidateBasic(); xerr != nil {
+					return xerrors.ErrInvalidTrxPayloadParams.Wrap(xerr)
 				}
 			}
 		}
@@ -287,8 +291,9 @@ func (ctrler *GovCtrler) freezeProposals(height int64) ([]v1.LedgerKey, []v1.Led
 }
 
 // applyProposals is called from EndBlock
-func (ctrler *GovCtrler) applyProposals(height int64) ([]v1.LedgerKey, xerrors.XError) {
+func (ctrler *GovCtrler) applyProposals(height int64) ([]v1.LedgerKey, []v1.LedgerKey, xerrors.XError) {
 	var applied []v1.LedgerKey
+	var rejected []v1.LedgerKey
 
 	defer func() {
 		if ctrler.newGovParams != nil {
@@ -296,6 +301,10 @@ func (ctrler *GovCtrler) applyProposals(height int64) ([]v1.LedgerKey, xerrors.X
 		}
 
 		for _, k := range applied {
+			// remove
+			_ = ctrler.govState.Del(k, true)
+		}
+		for _, k := range rejected {
 			// remove
 			_ = ctrler.govState.Del(k, true)
 		}
@@ -310,6 +319,8 @@ func (ctrler *GovCtrler) applyProposals(height int64) ([]v1.LedgerKey, xerrors.X
 			if prop.MajorOption() == nil {
 				// not reachable.
 				ctrler.logger.Error("Apply proposal", "error", "major option is nil")
+				rejected = append(rejected, key)
+				return nil
 			}
 
 			switch prop.Header().PropType {
@@ -319,10 +330,16 @@ func (ctrler *GovCtrler) applyProposals(height int64) ([]v1.LedgerKey, xerrors.X
 				strOpt := string(prop.MajorOption().Option)
 				if err := jsonx.Unmarshal([]byte(strOpt), newGovParams); err != nil {
 					ctrler.logger.Error("Apply proposal", "error", err, "option", string(prop.MajorOption().Option))
-					return xerrors.From(err)
+					rejected = append(rejected, key)
+					return nil
 				}
 
 				ctrlertypes.MergeGovParams(&ctrler.GovParams, newGovParams)
+				if xerr := newGovParams.ValidateBasic(); xerr != nil {
+					ctrler.logger.Error("Apply proposal", "error", xerr, "option", string(prop.MajorOption().Option))
+					rejected = append(rejected, key)
+					return nil
+				}
 				ctrler.newGovParams = newGovParams
 			default:
 				ctrler.logger.Debug("Apply proposal", "key(txHash)", prop.Header().TxHash, "type", prop.Header().PropType)
@@ -334,7 +351,7 @@ func (ctrler *GovCtrler) applyProposals(height int64) ([]v1.LedgerKey, xerrors.X
 		return nil
 	}, true)
 
-	return applied, xerr
+	return applied, rejected, xerr
 }
 
 func (ctrler *GovCtrler) Close() xerrors.XError {

--- a/ctrlers/gov/ctrler_block.go
+++ b/ctrlers/gov/ctrler_block.go
@@ -49,7 +49,7 @@ func (ctrler *GovCtrler) EndBlock(ctx *types.BlockContext) ([]types2.Event, xerr
 		return nil, xerr
 	}
 
-	applied, xerr := ctrler.applyProposals(ctx.Height())
+	applied, rejected, xerr := ctrler.applyProposals(ctx.Height())
 	if xerr != nil {
 		return nil, xerr
 	}
@@ -75,6 +75,14 @@ func (ctrler *GovCtrler) EndBlock(ctx *types.BlockContext) ([]types2.Event, xerr
 			Type: "proposal",
 			Attributes: []types2.EventAttribute{
 				{Key: []byte("applied"), Value: []byte(hex.EncodeToString(v1.UnwrapKeyPrefix(k))), Index: true},
+			},
+		})
+	}
+	for _, k := range rejected {
+		evts = append(evts, types2.Event{
+			Type: "proposal",
+			Attributes: []types2.EventAttribute{
+				{Key: []byte("rejected"), Value: []byte(hex.EncodeToString(v1.UnwrapKeyPrefix(k))), Index: true},
 			},
 		})
 	}

--- a/ctrlers/types/gov_params.go
+++ b/ctrlers/types/gov_params.go
@@ -93,6 +93,115 @@ func (govParams *GovParams) Decode(k, v []byte) xerrors.XError {
 	return nil
 }
 
+func (govParams *GovParams) ValidateBasic() xerrors.XError {
+	govParams.mtx.RLock()
+	v := govParams._v
+	govParams.mtx.RUnlock()
+
+	if v.EmptyBlockIntervalSecs <= 0 {
+		return xerrors.NewOrdinary("invalid governance params").Wrapf("emptyBlockIntervalSecs must be positive")
+	}
+	if v.MaxValidatorCnt <= 0 {
+		return xerrors.NewOrdinary("invalid governance params").Wrapf("maxValidatorCnt must be positive")
+	}
+	if v.MinValidatorPower < 0 {
+		return xerrors.NewOrdinary("invalid governance params").Wrapf("minValidatorPower must be non-negative")
+	}
+	if v.MinDelegatorPower < 0 {
+		return xerrors.NewOrdinary("invalid governance params").Wrapf("minDelegatorPower must be non-negative")
+	}
+	if v.MaxValidatorsOfDelegator <= 0 {
+		return xerrors.NewOrdinary("invalid governance params").Wrapf("maxValidatorsOfDelegator must be positive")
+	}
+	if v.MaxDelegatorsOfValidator <= 0 {
+		return xerrors.NewOrdinary("invalid governance params").Wrapf("maxDelegatorsOfValidator must be positive")
+	}
+	if xerr := validatePercentRate("minSelfPowerRate", v.MinSelfPowerRate); xerr != nil {
+		return xerr
+	}
+	if xerr := validatePercentRate("maxUpdatablePowerRate", v.MaxUpdatablePowerRate); xerr != nil {
+		return xerr
+	}
+	if xerr := validatePercentRate("maxIndividualPowerRate", v.MaxIndividualPowerRate); xerr != nil {
+		return xerr
+	}
+	if v.MinBondingBlocks < 0 {
+		return xerrors.NewOrdinary("invalid governance params").Wrapf("minBondingBlocks must be non-negative")
+	}
+	if v.MinSignedBlocks < 0 {
+		return xerrors.NewOrdinary("invalid governance params").Wrapf("minSignedBlocks must be non-negative")
+	}
+	if v.LazyUnbondingBlocks < 0 {
+		return xerrors.NewOrdinary("invalid governance params").Wrapf("lazyUnbondingBlocks must be non-negative")
+	}
+	if new(uint256.Int).SetBytes(v.XMaxTotalSupply).IsZero() {
+		return xerrors.NewOrdinary("invalid governance params").Wrapf("maxTotalSupply must be positive")
+	}
+	if xerr := validatePermilRate("inflationWeightPermil", v.InflationWeightPermil); xerr != nil {
+		return xerr
+	}
+	if v.InflationCycleBlocks <= 0 {
+		return xerrors.NewOrdinary("invalid governance params").Wrapf("inflationCycleBlocks must be positive")
+	}
+	if xerr := validatePermilRate("bondingBlocksWeightPermil", v.BondingBlocksWeightPermil); xerr != nil {
+		return xerr
+	}
+	if v.RipeningBlocks < 0 {
+		return xerrors.NewOrdinary("invalid governance params").Wrapf("ripeningBlocks must be non-negative")
+	}
+	if len(v.XRewardPoolAddress) != types.AddrSize {
+		return xerrors.NewOrdinary("invalid governance params").Wrapf("rewardPoolAddress must be %d bytes", types.AddrSize)
+	}
+	if len(v.XDeadAddress) != types.AddrSize {
+		return xerrors.NewOrdinary("invalid governance params").Wrapf("deadAddress must be %d bytes", types.AddrSize)
+	}
+	if xerr := validatePercentRate("validatorRewardRate", v.ValidatorRewardRate); xerr != nil {
+		return xerr
+	}
+	if xerr := validatePercentRate("txFeeRewardRate", v.TxFeeRewardRate); xerr != nil {
+		return xerr
+	}
+	if xerr := validatePercentRate("slashRate", v.SlashRate); xerr != nil {
+		return xerr
+	}
+	if new(uint256.Int).SetBytes(v.XGasPrice).IsZero() {
+		return xerrors.NewOrdinary("invalid governance params").Wrapf("gasPrice must be positive")
+	}
+	if v.MinTrxGas <= 0 {
+		return xerrors.NewOrdinary("invalid governance params").Wrapf("minTrxGas must be positive")
+	}
+	if v.BlockSizeLimit <= 0 {
+		return xerrors.NewOrdinary("invalid governance params").Wrapf("blockSizeLimit must be positive")
+	}
+	if v.BlockGasLimit <= 0 {
+		return xerrors.NewOrdinary("invalid governance params").Wrapf("blockGasLimit must be positive")
+	}
+	if v.MinVotingPeriodBlocks <= 0 {
+		return xerrors.NewOrdinary("invalid governance params").Wrapf("minVotingPeriodBlocks must be positive")
+	}
+	if v.MaxVotingPeriodBlocks < v.MinVotingPeriodBlocks {
+		return xerrors.NewOrdinary("invalid governance params").Wrapf("maxVotingPeriodBlocks must be greater than or equal to minVotingPeriodBlocks")
+	}
+	if v.LazyApplyingBlocks < 0 {
+		return xerrors.NewOrdinary("invalid governance params").Wrapf("lazyApplyingBlocks must be non-negative")
+	}
+	return nil
+}
+
+func validatePercentRate(name string, rate int32) xerrors.XError {
+	if rate < 0 || rate > 100 {
+		return xerrors.NewOrdinary("invalid governance params").Wrapf("%s must be in [0, 100]", name)
+	}
+	return nil
+}
+
+func validatePermilRate(name string, rate int32) xerrors.XError {
+	if rate < 0 || rate > 1000 {
+		return xerrors.NewOrdinary("invalid governance params").Wrapf("%s must be in [0, 1000]", name)
+	}
+	return nil
+}
+
 func (govParams *GovParams) MarshalJSON() ([]byte, error) {
 	govParams.mtx.RLock()
 	defer govParams.mtx.RUnlock()

--- a/ctrlers/types/gov_params_test.go
+++ b/ctrlers/types/gov_params_test.go
@@ -37,3 +37,59 @@ func Test_JsonCodec(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, jz, jz2)
 }
+
+func TestGovParamsValidateBasic(t *testing.T) {
+	require.NoError(t, DefaultGovParams().ValidateBasic())
+}
+
+func TestGovParamsValidateBasic_InvalidValues(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*GovParamsProto)
+	}{
+		{
+			name: "negative_max_validator_count",
+			mutate: func(v *GovParamsProto) {
+				v.MaxValidatorCnt = -1
+			},
+		},
+		{
+			name: "zero_inflation_cycle_blocks",
+			mutate: func(v *GovParamsProto) {
+				v.InflationCycleBlocks = 0
+			},
+		},
+		{
+			name: "negative_inflation_cycle_blocks",
+			mutate: func(v *GovParamsProto) {
+				v.InflationCycleBlocks = -1
+			},
+		},
+		{
+			name: "negative_block_gas_limit",
+			mutate: func(v *GovParamsProto) {
+				v.BlockGasLimit = -1
+			},
+		},
+		{
+			name: "tx_fee_reward_rate_over_100",
+			mutate: func(v *GovParamsProto) {
+				v.TxFeeRewardRate = 200
+			},
+		},
+		{
+			name: "slash_rate_over_100",
+			mutate: func(v *GovParamsProto) {
+				v.SlashRate = 200
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := DefaultGovParams()
+			params.SetValue(tt.mutate)
+			require.Error(t, params.ValidateBasic())
+		})
+	}
+}

--- a/test/81_governance_test.go
+++ b/test/81_governance_test.go
@@ -50,7 +50,7 @@ func TestIncorrectProposal(t *testing.T) {
 	newGovParams := &types.GovParams{}
 	newGovParams.SetValue(func(v *types.GovParamsProto) {
 		v.Version = rand.Int32()
-		v.SlashRate = rand.Int32()
+		v.SlashRate = int32(rand.Intn(101))
 		v.XRewardPoolAddress = bytes.RandBytes(20)
 	})
 	bzOpt, err = jsonx.Marshal(newGovParams)
@@ -108,7 +108,7 @@ func TestProposalAndVoting(t *testing.T) {
 	newGovParams := &types.GovParams{}
 	newGovParams.SetValue(func(v *types.GovParamsProto) {
 		v.Version = rand.Int32()
-		v.SlashRate = rand.Int32()
+		v.SlashRate = int32(rand.Intn(101))
 		v.XRewardPoolAddress = bytes.RandBytes(20)
 	})
 	bzOpt, err := jsonx.Marshal(newGovParams)


### PR DESCRIPTION
# Validate Governance Parameter Proposals Before Applying

## Summary

This PR prevents invalid governance parameter proposals from being accepted or applied.

Previously, `PROPOSAL_GOVPARAMS` options were only checked for JSON decode validity. As a result, semantically invalid parameters such as negative validator limits, invalid cycle blocks, or percentage rates above 100 could pass proposal validation and later reach consensus-critical block processing paths.

The specific issue addressed by this PR is tracked in [BG-594](https://beatoz.atlassian.net/jira/software/projects/BG/boards/82?selectedIssue=BG-594).

## Changes

- Add `GovParams.ValidateBasic()` to enforce basic range and consistency checks for governance parameters.
- Validate each governance parameter proposal option after merging it with the current parameters.
- Revalidate frozen governance parameter proposals before applying them in `EndBlock`.
- Reject and remove malformed frozen proposals without returning an `EndBlock` error.
- Emit a `proposal` event with a `rejected` attribute when an invalid frozen proposal is skipped.
- Add regression tests for invalid governance parameter validation and rejected proposal application.

## Changed Files

- `ctrlers/types/gov_params.go`: adds semantic validation for governance parameters, including positive counts and limits, address length checks, percent and permil ranges, and voting period consistency.
- `ctrlers/types/gov_params_test.go`: adds validation coverage for default parameters and representative invalid values.
- `ctrlers/gov/ctrler.go`: validates governance parameter proposal options during transaction validation and rejects invalid frozen proposals during application.
- `ctrlers/gov/ctrler_block.go`: includes rejected proposal keys in `EndBlock` events.
- `ctrlers/gov/1_proposal_test.go`: adds proposal validation coverage for invalid governance parameter options.
- `ctrlers/gov/2_voting_test.go`: adds regression coverage to ensure invalid frozen governance parameter proposals are rejected without changing committed params.
- `test/81_governance_test.go`: constrains randomized slash rate test values to the newly enforced valid percent range.

## Test

```bash
go test ./ctrlers/types
go test ./ctrlers/gov
```

Result:

```text
ok  	github.com/beatoz/beatoz-go/ctrlers/types	1.306s
ok  	github.com/beatoz/beatoz-go/ctrlers/gov	1.000s
```
