### PR TITLE
Prevent TrxPreparer Worker Panic from Crashing the Validator

### DIFF
--- a/node/trx_executor.go
+++ b/node/trx_executor.go
@@ -18,7 +18,7 @@ type TrxExecutor struct {
 
 func NewTrxExecutor(logger log.Logger) *TrxExecutor {
 	return &TrxExecutor{
-		TrxPreparer: newTrxPreparer(),
+		TrxPreparer: newTrxPreparer(logger),
 		logger:      logger,
 	}
 }

--- a/node/trx_preparer.go
+++ b/node/trx_preparer.go
@@ -1,11 +1,15 @@
 package node
 
 import (
-	"github.com/beatoz/beatoz-go/ctrlers/types"
-	abcitypes "github.com/tendermint/tendermint/abci/types"
 	"runtime"
+	"runtime/debug"
 	"sync"
 	"sync/atomic"
+
+	"github.com/beatoz/beatoz-go/ctrlers/types"
+	"github.com/beatoz/beatoz-go/types/xerrors"
+	abcitypes "github.com/tendermint/tendermint/abci/types"
+	"github.com/tendermint/tendermint/libs/log"
 )
 
 type requestParam struct {
@@ -34,13 +38,15 @@ type TrxPreparer struct {
 	started uint32 // atomic
 	stopped uint32 // atomic
 	mtx     sync.RWMutex
+	logger  log.Logger
 }
 
-func newTrxPreparer() *TrxPreparer {
+func newTrxPreparer(logger log.Logger) *TrxPreparer {
 	return &TrxPreparer{
 		WaitGroup:   &sync.WaitGroup{},
 		chDone:      make(chan struct{}),
 		chReqParams: make([]chan *requestParam, runtime.GOMAXPROCS(0)),
+		logger:      logger,
 	}
 }
 
@@ -48,7 +54,7 @@ func (tp *TrxPreparer) start() {
 	if atomic.CompareAndSwapUint32(&tp.started, 0, 1) {
 		for i := 0; i < len(tp.chReqParams); i++ {
 			tp.chReqParams[i] = make(chan *requestParam, 5000)
-			go trxPreparerRoutine(tp.chReqParams[i], tp.chDone, i)
+			go tp.trxPreparerRoutine(tp.chReqParams[i], tp.chDone, i)
 		}
 	}
 }
@@ -113,13 +119,44 @@ func (tp *TrxPreparer) resultList() []*resultValue {
 	return tp.resultValues
 }
 
-func trxPreparerRoutine(chReqParams chan *requestParam, done chan struct{}, no int) {
+func (tp *TrxPreparer) prepareSafe(param *requestParam, workerNo int) (ret *resultValue) {
+	ret = &resultValue{
+		idx:          param.idx,
+		reqDeliverTx: param.req,
+	}
+
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			xerr := xerrors.ErrDeliverTx.Wrapf("transaction preparation failed")
+			ret.txctx = nil
+			ret.resDeliverTx = &abcitypes.ResponseDeliverTx{
+				Code: xerr.Code(),
+				Log:  xerr.Error(),
+			}
+
+			if tp.logger != nil {
+				tp.logger.Error(
+					"panic while preparing transaction",
+					"worker", workerNo,
+					"txIndex", param.idx,
+					"panic", recovered,
+					"stack", string(debug.Stack()),
+				)
+			}
+		}
+	}()
+
+	ret.txctx, ret.resDeliverTx = param.onPrepare(param.req, param.idx)
+	return ret
+}
+
+func (tp *TrxPreparer) trxPreparerRoutine(chReqParams chan *requestParam, done chan struct{}, no int) {
 STOP:
 	for {
 		select {
 		case param := <-chReqParams:
-			_txctx, _resp := param.onPrepare(param.req, param.idx)
-			param.onCompleted(&resultValue{param.idx, param.req, _resp, _txctx})
+			ret := tp.prepareSafe(param, no)
+			param.onCompleted(ret)
 		case <-done:
 			break STOP
 		}

--- a/node/trx_preparer_test.go
+++ b/node/trx_preparer_test.go
@@ -6,14 +6,16 @@ import (
 
 	"github.com/beatoz/beatoz-go/ctrlers/mocks"
 	"github.com/beatoz/beatoz-go/ctrlers/types"
+	"github.com/beatoz/beatoz-go/types/xerrors"
 	"github.com/beatoz/beatoz-sdk-go/web3"
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 	abcitypes "github.com/tendermint/tendermint/abci/types"
+	"github.com/tendermint/tendermint/libs/log"
 )
 
 var (
-	txPreparer = newTrxPreparer()
+	txPreparer = newTrxPreparer(log.NewNopLogger())
 	txReqs     []*abcitypes.RequestDeliverTx
 )
 
@@ -75,4 +77,59 @@ func TestNilResult(t *testing.T) {
 
 		txPreparer.reset()
 	}
+}
+
+func TestTrxPreparerPanic(t *testing.T) {
+	tp := newTrxPreparer(log.NewNopLogger())
+	tp.start()
+	defer tp.stop()
+
+	reqCount := len(tp.chReqParams) + 1
+	reqs := make([]*abcitypes.RequestDeliverTx, reqCount)
+	for i := 0; i < reqCount; i++ {
+		reqs[i] = &abcitypes.RequestDeliverTx{Tx: []byte{byte(i)}}
+		tp.Add(reqs[i], func(_ *abcitypes.RequestDeliverTx, idx int) (*types.TrxContext, *abcitypes.ResponseDeliverTx) {
+			if idx == 0 {
+				panic("prepare panic")
+			}
+			return &types.TrxContext{}, nil
+		})
+	}
+
+	done := make(chan struct{})
+	go func() {
+		tp.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("TrxPreparer.Wait() hung after prepare panic")
+	}
+
+	require.Equal(t, reqCount, tp.resultCount())
+
+	panicRet := tp.resultAt(0)
+	require.NotNil(t, panicRet)
+	require.Equal(t, 0, panicRet.idx)
+	require.Same(t, reqs[0], panicRet.reqDeliverTx)
+	require.Nil(t, panicRet.txctx)
+	require.NotNil(t, panicRet.resDeliverTx)
+
+	expectedErr := xerrors.ErrDeliverTx.Wrapf("transaction preparation failed")
+	require.Equal(t, expectedErr.Code(), panicRet.resDeliverTx.Code)
+	require.Equal(t, expectedErr.Error(), panicRet.resDeliverTx.Log)
+
+	for idx, ret := range tp.resultList() {
+		require.NotNil(t, ret, "result is nil at index %d", idx)
+		require.Equal(t, idx, ret.idx)
+		require.Same(t, reqs[idx], ret.reqDeliverTx)
+	}
+
+	// Index 0 and reqCount-1 are assigned to the same worker.
+	// A non-nil result confirms that the worker continued after recovering.
+	lastRet := tp.resultAt(reqCount - 1)
+	require.NotNil(t, lastRet.txctx)
+	require.Nil(t, lastRet.resDeliverTx)
 }


### PR DESCRIPTION
# Prevent TrxPreparer Worker Panic from Crashing the Validator

## Summary

This PR prevents an unexpected panic in a `TrxPreparer` callback from propagating out of the worker goroutine and crashing the validator process.

Previously, a panic during transaction preparation skipped result storage and `WaitGroup.Done()`. Recovering the panic without completing the request could also leave `EndBlock` waiting indefinitely or cause a nil result panic.

The specific issue addressed by this PR is tracked in [BG-596](https://beatoz.atlassian.net/jira/software/projects/BG/boards/82?selectedIssue=BG-596).

## Changes

- Add request-level panic recovery around transaction preparation callbacks.
- Convert preparation panics into deterministic non-OK `ResponseDeliverTx` results.
- Ensure panic results are stored through the existing completion path and `WaitGroup.Done()` is called.
- Keep workers running so they can process subsequent requests after recovering from a panic.
- Log the worker number, transaction index, recovered panic, and stack trace for diagnosis.
- Add regression coverage for completion, result ordering, error response generation, and worker continuation after a panic.

## Changed Files

- `node/trx_preparer.go`: adds panic-safe callback execution, deterministic error results, diagnostic logging, and completion handling.
- `node/trx_executor.go`: passes the existing logger to `TrxPreparer`.
- `node/trx_preparer_test.go`: adds regression coverage for callback panic recovery and subsequent request processing.

## Test

```bash
go test ./node -count=1
go test -race ./node -run 'TestTrxPreparerPanic|TestNilResult' -count=1
```

Result:

```text
ok  	github.com/beatoz/beatoz-go/node	1.710s
ok  	github.com/beatoz/beatoz-go/node	15.810s