### PR TITLE
Harden Ledger Snapshot and Rollback Handling

### DIFF
--- a/ledger/v1/mem_ledger.go
+++ b/ledger/v1/mem_ledger.go
@@ -188,27 +188,39 @@ func (ledger *MemLedger) Del(key LedgerKey) xerrors.XError {
 	defer ledger.mtx.Unlock()
 
 	keystr := unsafe.String(&key[0], len(key))
-	if oldVal, ok := ledger.memStorage[keystr]; ok {
-		ledger.revisions.set(key, oldVal)
+	oldVal, ok := ledger.memStorage[keystr]
+	if !ok && ledger.immuTree != nil {
+		var err error
+		oldVal, err = ledger.immuTree.Get(key)
+		if err != nil {
+			return xerrors.From(err)
+		}
+	}
+	if oldVal == nil {
+		return nil
 	}
 
+	ledger.revisions.set(key, oldVal)
 	ledger.memStorage[keystr] = nil // delete from memory. don't read from immuTree.
-
 	return nil
 }
 
-func (ledger *MemLedger) Snapshot() int {
+func (ledger *MemLedger) Snapshot() Snapshot {
 	ledger.mtx.RLock()
 	defer ledger.mtx.RUnlock()
 
 	return ledger.revisions.snapshot()
 }
 
-func (ledger *MemLedger) RevertToSnapshot(snap int) xerrors.XError {
+func (ledger *MemLedger) RevertToSnapshot(snap Snapshot) xerrors.XError {
 	ledger.mtx.Lock()
 	defer ledger.mtx.Unlock()
 
-	restores := ledger.revisions.revs[snap:]
+	if xerr := ledger.revisions.validateSnapshot(snap); xerr != nil {
+		return xerr
+	}
+
+	restores := ledger.revisions.revs[snap.revision:]
 	for i := len(restores) - 1; i >= 0; i-- {
 		kv := restores[i]
 		keystr := unsafe.String(&kv.key[0], len(kv.key))

--- a/ledger/v1/mem_ledger_test.go
+++ b/ledger/v1/mem_ledger_test.go
@@ -131,12 +131,16 @@ func TestMemLedger_RevertToSnapshot_Set1(t *testing.T) {
 	for i := 0; i < 10000; i++ {
 		oriItems = append(oriItems, newItem(i, fmt.Sprintf("d%d", i)))
 	}
-	for _, it := range oriItems {
+	var firstSnap Snapshot
+	for i, it := range oriItems {
 		require.NoError(t, ledger.Set(it.Key(), it))
+		if i == 0 {
+			firstSnap = ledger.Snapshot()
+		}
 	}
 
 	snap := ledger.Snapshot()
-	require.Equal(t, 10000, snap)
+	require.Equal(t, 10000, snap.revision)
 
 	var newItems []*Item
 	for i := 0; i < 10000; i++ {
@@ -164,7 +168,7 @@ func TestMemLedger_RevertToSnapshot_Set1(t *testing.T) {
 		require.Equal(t, fmt.Sprintf("d%d", i), item.(*Item).data)
 	}
 
-	require.NoError(t, ledger.RevertToSnapshot(1))
+	require.NoError(t, ledger.RevertToSnapshot(firstSnap))
 	k := make([]byte, 4)
 	binary.BigEndian.PutUint32(k, uint32(0))
 	item, xerr := ledger.Get(k)
@@ -185,18 +189,21 @@ func TestMemLedger_RevertToSnapshot_Set2(t *testing.T) {
 	require.NoError(t, xerr)
 
 	staticKey := 123
+	snapshots := make([]Snapshot, 10001)
+	snapshots[0] = ledger.Snapshot()
 	for i := 0; i < 10000; i++ {
 		// key 고정
 		item := newItem(staticKey, strconv.Itoa(i))
 		xerr := ledger.Set(item.Key(), item)
 		require.NoError(t, xerr)
+		snapshots[i+1] = ledger.Snapshot()
 	}
 
-	require.Equal(t, 10000, ledger.Snapshot())
+	require.Equal(t, 10000, ledger.Snapshot().revision)
 
 	for i := 10000; i >= 0; i-- {
 		// partially revert
-		require.NoError(t, ledger.RevertToSnapshot(i))
+		require.NoError(t, ledger.RevertToSnapshot(snapshots[i]))
 
 		k := make([]byte, 4)
 		binary.BigEndian.PutUint32(k, uint32(staticKey))
@@ -225,7 +232,7 @@ func TestMemLedger_RevertToSnapshot_Set_Updated(t *testing.T) {
 	require.NoError(t, xerr)
 
 	snap := ledger.Snapshot()
-	require.Equal(t, 1, snap)
+	require.Equal(t, 1, snap.revision)
 
 	_item0, xerr := ledger.Get(item.Key())
 	require.NoError(t, xerr)
@@ -259,7 +266,7 @@ func TestMemLedger_RevertToSnapshot_Del(t *testing.T) {
 
 	// get snapshot
 	snap := ledger.Snapshot()
-	require.Equal(t, 1, snap)
+	require.Equal(t, 1, snap.revision)
 
 	// delete item
 	require.NoError(t, ledger.Del(item.Key()))
@@ -272,4 +279,165 @@ func TestMemLedger_RevertToSnapshot_Del(t *testing.T) {
 	require.NoError(t, xerr)
 	require.Equal(t, item.Key(), _item.(*Item).Key())
 	require.Equal(t, item.data, _item.(*Item).data)
+}
+
+func TestMemLedger_RevertToSnapshot_DelCommittedItem(t *testing.T) {
+	ledger, xerr := NewMemLedgerAt(1, sourceLedger, log.NewNopLogger())
+	require.NoError(t, xerr)
+
+	snap := ledger.Snapshot()
+	require.NoError(t, ledger.Del(preExistedItem.Key()))
+	require.Equal(t, snap.revision+1, ledger.Snapshot().revision)
+
+	_, xerr = ledger.Get(preExistedItem.Key())
+	require.Error(t, xerr)
+	require.True(t, xerr.Contains(xerrors.ErrNotFoundResult))
+
+	require.NoError(t, ledger.RevertToSnapshot(snap))
+	restored, xerr := ledger.Get(preExistedItem.Key())
+	require.NoError(t, xerr)
+	require.Equal(t, preExistedItem.data, restored.(*Item).data)
+}
+
+func TestMemLedger_DelDoesNotRecordDuplicateRevision(t *testing.T) {
+	ledger, xerr := NewMemLedgerAt(1, sourceLedger, log.NewNopLogger())
+	require.NoError(t, xerr)
+
+	require.NoError(t, ledger.Del(preExistedItem.Key()))
+	afterFirstDelete := ledger.Snapshot()
+	require.NoError(t, ledger.Del(preExistedItem.Key()))
+	require.Equal(t, afterFirstDelete, ledger.Snapshot())
+
+	missingKey := newItem(987654, "").Key()
+	beforeMissingDelete := ledger.Snapshot()
+	require.NoError(t, ledger.Del(missingKey))
+	require.Equal(t, beforeMissingDelete, ledger.Snapshot())
+}
+
+func TestMemLedger_RevertToSnapshotRejectsInvalidSnapshot(t *testing.T) {
+	ledger, xerr := NewMemLedgerAt(1, sourceLedger, log.NewNopLogger())
+	require.NoError(t, xerr)
+
+	t.Run("zero value", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			xerr := ledger.RevertToSnapshot(Snapshot{})
+			require.Error(t, xerr)
+			require.True(t, xerr.Contains(xerrors.ErrInvalidSnapshot))
+		})
+	})
+
+	t.Run("foreign ledger", func(t *testing.T) {
+		otherLedger, xerr := NewMemLedgerAt(1, sourceLedger, log.NewNopLogger())
+		require.NoError(t, xerr)
+
+		require.NotPanics(t, func() {
+			xerr = ledger.RevertToSnapshot(otherLedger.Snapshot())
+			require.Error(t, xerr)
+			require.True(t, xerr.Contains(xerrors.ErrInvalidSnapshot))
+		})
+	})
+
+	t.Run("generation mismatch", func(t *testing.T) {
+		snap := ledger.Snapshot()
+		snap.generation++
+
+		require.NotPanics(t, func() {
+			xerr := ledger.RevertToSnapshot(snap)
+			require.Error(t, xerr)
+			require.True(t, xerr.Contains(xerrors.ErrInvalidSnapshot))
+		})
+	})
+
+	t.Run("revision out of range", func(t *testing.T) {
+		snap := ledger.Snapshot()
+		snap.revision++
+
+		require.NotPanics(t, func() {
+			xerr := ledger.RevertToSnapshot(snap)
+			require.Error(t, xerr)
+			require.True(t, xerr.Contains(xerrors.ErrInvalidSnapshot))
+		})
+	})
+
+	t.Run("negative revision", func(t *testing.T) {
+		snap := ledger.Snapshot()
+		snap.revision = -1
+
+		require.NotPanics(t, func() {
+			xerr := ledger.RevertToSnapshot(snap)
+			require.Error(t, xerr)
+			require.True(t, xerr.Contains(xerrors.ErrInvalidSnapshot))
+		})
+	})
+}
+
+func TestMemLedger_SnapshotLifecycle(t *testing.T) {
+	newLedger := func(t *testing.T) *MemLedger {
+		t.Helper()
+
+		ledger, xerr := NewMemLedgerAt(1, sourceLedger, log.NewNopLogger())
+		require.NoError(t, xerr)
+		return ledger
+	}
+
+	t.Run("inner then outer revert", func(t *testing.T) {
+		ledger := newLedger(t)
+		key := newItem(701, "").Key()
+
+		require.NoError(t, ledger.Set(key, newItem(701, "base")))
+		outer := ledger.Snapshot()
+		require.NoError(t, ledger.Set(key, newItem(701, "outer")))
+		inner := ledger.Snapshot()
+		require.NoError(t, ledger.Set(key, newItem(701, "inner")))
+
+		require.NoError(t, ledger.RevertToSnapshot(inner))
+		requireSnapshotItemData(t, ledger, key, "outer")
+		require.NoError(t, ledger.RevertToSnapshot(outer))
+		requireSnapshotItemData(t, ledger, key, "base")
+	})
+
+	t.Run("outer then inner revert is rejected while out of range", func(t *testing.T) {
+		ledger := newLedger(t)
+		key := newItem(702, "").Key()
+
+		outer := ledger.Snapshot()
+		require.NoError(t, ledger.Set(key, newItem(702, "outer")))
+		inner := ledger.Snapshot()
+		require.NoError(t, ledger.Set(key, newItem(702, "inner")))
+
+		require.NoError(t, ledger.RevertToSnapshot(outer))
+		xerr := ledger.RevertToSnapshot(inner)
+		require.Error(t, xerr)
+		require.True(t, xerr.Contains(xerrors.ErrInvalidSnapshot))
+	})
+
+	t.Run("same snapshot can be reused as no-op", func(t *testing.T) {
+		ledger := newLedger(t)
+		key := newItem(703, "").Key()
+
+		snap := ledger.Snapshot()
+		require.NoError(t, ledger.Set(key, newItem(703, "created")))
+		require.NoError(t, ledger.RevertToSnapshot(snap))
+		require.NoError(t, ledger.RevertToSnapshot(snap))
+
+		_, xerr := ledger.Get(key)
+		require.Error(t, xerr)
+		require.True(t, xerr.Contains(xerrors.ErrNotFoundResult))
+	})
+
+	t.Run("old marker is valid when revision position is reused", func(t *testing.T) {
+		ledger := newLedger(t)
+		firstKey := newItem(704, "").Key()
+		secondKey := newItem(705, "").Key()
+
+		outer := ledger.Snapshot()
+		require.NoError(t, ledger.Set(firstKey, newItem(704, "first")))
+		oldInner := ledger.Snapshot()
+		require.NoError(t, ledger.RevertToSnapshot(outer))
+
+		require.NoError(t, ledger.Set(secondKey, newItem(705, "second")))
+		require.Equal(t, oldInner.revision, ledger.Snapshot().revision)
+		require.NoError(t, ledger.RevertToSnapshot(oldInner))
+		requireSnapshotItemData(t, ledger, secondKey, "second")
+	})
 }

--- a/ledger/v1/mutable_ledger.go
+++ b/ledger/v1/mutable_ledger.go
@@ -196,34 +196,40 @@ func (ledger *MutableLedger) Del(key LedgerKey) xerrors.XError {
 	return nil
 }
 
-func (ledger *MutableLedger) Snapshot() int {
+func (ledger *MutableLedger) Snapshot() Snapshot {
 	ledger.mtx.RLock()
 	defer ledger.mtx.RUnlock()
 
 	return ledger.revisions.snapshot()
 }
 
-func (ledger *MutableLedger) RevertToSnapshot(snap int) xerrors.XError {
+func (ledger *MutableLedger) RevertToSnapshot(snap Snapshot) xerrors.XError {
 	ledger.mtx.Lock()
 	defer ledger.mtx.Unlock()
 
-	restores := ledger.revisions.revs[snap:]
+	if xerr := ledger.revisions.validateSnapshot(snap); xerr != nil {
+		return xerr
+	}
+
+	// A failed restore can leave the tree partially reverted. Do not allow
+	// callers to read objects cached from before the revert attempt.
+	ledger.cachedObjs = make(map[string]ILedgerItem)
+
+	restores := ledger.revisions.revs[snap.revision:]
 	for i := len(restores) - 1; i >= 0; i-- {
 		kv := restores[i]
 		if kv.val != nil {
 			if _, err := ledger.tree.Set(kv.key, kv.val); err != nil {
-				return xerrors.From(err)
+				return xerrors.ErrFatalLedger.Wrap(
+					xerrors.Wrap(err, "revert snapshot set failed"),
+				)
 			}
-			restoreItem := ledger.newItemFor(kv.key)
-			if xerr := restoreItem.Decode(kv.key, kv.val); xerr != nil {
-				return xerr
-			}
-			ledger.cachedObjs[unsafe.String(&kv.key[0], len(kv.key))] = restoreItem
 		} else {
 			if _, _, err := ledger.tree.Remove(kv.key); err != nil {
-				return xerrors.From(err)
+				return xerrors.ErrFatalLedger.Wrap(
+					xerrors.Wrap(err, "revert snapshot remove failed"),
+				)
 			}
-			delete(ledger.cachedObjs, unsafe.String(&kv.key[0], len(kv.key)))
 		}
 	}
 	ledger.revisions.revert(snap)

--- a/ledger/v1/mutable_ledger_test.go
+++ b/ledger/v1/mutable_ledger_test.go
@@ -2,8 +2,11 @@ package v1
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"github.com/beatoz/beatoz-go/types/xerrors"
+	"github.com/cosmos/iavl"
+	dbm "github.com/cosmos/iavl/db"
 	"github.com/stretchr/testify/require"
 	"github.com/tendermint/tendermint/libs/log"
 	"os"
@@ -67,12 +70,16 @@ func TestMutableLedger_RevertToSnapshot_Set1(t *testing.T) {
 	for i := 0; i < 10000; i++ {
 		oriItems = append(oriItems, newItem(i, fmt.Sprintf("origin:%d", i)))
 	}
-	for _, it := range oriItems {
+	var firstSnap Snapshot
+	for i, it := range oriItems {
 		require.NoError(t, ledger.Set(it.Key(), it))
+		if i == 0 {
+			firstSnap = ledger.Snapshot()
+		}
 	}
 
 	snap := ledger.Snapshot()
-	require.Equal(t, 10000, snap)
+	require.Equal(t, 10000, snap.revision)
 
 	var newItems []*Item
 	for i := 0; i < 10000; i++ {
@@ -100,7 +107,7 @@ func TestMutableLedger_RevertToSnapshot_Set1(t *testing.T) {
 		require.Equal(t, fmt.Sprintf("origin:%d", i), item.(*Item).data)
 	}
 
-	require.NoError(t, ledger.RevertToSnapshot(1))
+	require.NoError(t, ledger.RevertToSnapshot(firstSnap))
 	k := make([]byte, 4)
 	binary.BigEndian.PutUint32(k, uint32(0))
 	item, xerr := ledger.Get(k)
@@ -129,18 +136,21 @@ func TestMutableLedger_RevertToSnapshot_Set2(t *testing.T) {
 	require.NoError(t, xerr)
 
 	staticKey := 123
+	snapshots := make([]Snapshot, 10001)
+	snapshots[0] = ledger.Snapshot()
 	for i := 0; i < 10000; i++ {
 		// key 고정
 		item := newItem(staticKey, strconv.Itoa(i))
 		xerr := ledger.Set(item.Key(), item)
 		require.NoError(t, xerr)
+		snapshots[i+1] = ledger.Snapshot()
 	}
 
-	require.Equal(t, 10000, ledger.Snapshot())
+	require.Equal(t, 10000, ledger.Snapshot().revision)
 
 	for i := 10000; i >= 0; i-- {
 		// partially revert
-		require.NoError(t, ledger.RevertToSnapshot(i))
+		require.NoError(t, ledger.RevertToSnapshot(snapshots[i]))
 
 		k := make([]byte, 4)
 		binary.BigEndian.PutUint32(k, uint32(staticKey))
@@ -177,7 +187,7 @@ func TestMutableLedger_RevertToSnapshot_Set_Updated(t *testing.T) {
 	require.NoError(t, xerr)
 
 	snap := ledger.Snapshot()
-	require.Equal(t, 1, snap)
+	require.Equal(t, 1, snap.revision)
 
 	_item0, xerr := ledger.Get(item.Key())
 	require.NoError(t, xerr)
@@ -215,7 +225,7 @@ func TestMutableLedger_RevertToSnapshot_Del(t *testing.T) {
 
 	// get snapshot
 	snap := ledger.Snapshot()
-	require.Equal(t, 1, snap)
+	require.Equal(t, 1, snap.revision)
 
 	// delete item
 	require.NoError(t, ledger.Del(item.Key()))
@@ -231,6 +241,291 @@ func TestMutableLedger_RevertToSnapshot_Del(t *testing.T) {
 
 	require.NoError(t, ledger.Close())
 	require.NoError(t, os.RemoveAll(dbDir))
+}
+
+func TestMutableLedger_CommitResetsRevisions(t *testing.T) {
+	dbDir := t.TempDir()
+	ledger, xerr := NewMutableLedger("ledger_test", dbDir, 100, func(key LedgerKey) ILedgerItem {
+		return &Item{}
+	}, log.NewNopLogger())
+	require.NoError(t, xerr)
+	t.Cleanup(func() {
+		require.NoError(t, ledger.Close())
+	})
+
+	item := newItem(456, "data456")
+	require.NoError(t, ledger.Set(item.Key(), item))
+	beforeCommit := ledger.Snapshot()
+	require.Equal(t, 1, beforeCommit.revision)
+
+	_, _, xerr = ledger.Commit()
+	require.NoError(t, xerr)
+	afterCommit := ledger.Snapshot()
+	require.Equal(t, 0, afterCommit.revision)
+	require.Equal(t, beforeCommit.ledgerID, afterCommit.ledgerID)
+	require.NotEqual(t, beforeCommit.generation, afterCommit.generation)
+}
+
+func TestMutableLedger_SnapshotHasUniqueIdentity(t *testing.T) {
+	firstLedger := newMutableLedgerForSnapshotIdentityTest(t)
+	secondLedger := newMutableLedgerForSnapshotIdentityTest(t)
+
+	first := firstLedger.Snapshot()
+	second := firstLedger.Snapshot()
+	otherLedger := secondLedger.Snapshot()
+
+	require.NotZero(t, first.ledgerID)
+	require.NotZero(t, first.generation)
+	require.Equal(t, first.ledgerID, second.ledgerID)
+	require.Equal(t, first.generation, second.generation)
+	require.Equal(t, first, second)
+	require.NotEqual(t, first.ledgerID, otherLedger.ledgerID)
+}
+
+func TestMutableLedger_RevertToSnapshotRejectsInvalidSnapshot(t *testing.T) {
+	t.Run("zero value", func(t *testing.T) {
+		ledger := newMutableLedgerForSnapshotIdentityTest(t)
+
+		require.NotPanics(t, func() {
+			xerr := ledger.RevertToSnapshot(Snapshot{})
+			require.Error(t, xerr)
+			require.True(t, xerr.Contains(xerrors.ErrInvalidSnapshot))
+		})
+	})
+
+	t.Run("foreign ledger", func(t *testing.T) {
+		ledger := newMutableLedgerForSnapshotIdentityTest(t)
+		otherLedger := newMutableLedgerForSnapshotIdentityTest(t)
+
+		require.NotPanics(t, func() {
+			xerr := ledger.RevertToSnapshot(otherLedger.Snapshot())
+			require.Error(t, xerr)
+			require.True(t, xerr.Contains(xerrors.ErrInvalidSnapshot))
+		})
+	})
+
+	t.Run("stale generation", func(t *testing.T) {
+		ledger := newMutableLedgerForSnapshotIdentityTest(t)
+		require.NoError(t, ledger.Set(newItem(501, "").Key(), newItem(501, "committed")))
+		stale := ledger.Snapshot()
+		_, _, xerr := ledger.Commit()
+		require.NoError(t, xerr)
+
+		require.NotPanics(t, func() {
+			xerr = ledger.RevertToSnapshot(stale)
+			require.Error(t, xerr)
+			require.True(t, xerr.Contains(xerrors.ErrInvalidSnapshot))
+		})
+	})
+
+	t.Run("revision out of range", func(t *testing.T) {
+		ledger := newMutableLedgerForSnapshotIdentityTest(t)
+		snap := ledger.Snapshot()
+		snap.revision = 1
+
+		require.NotPanics(t, func() {
+			xerr := ledger.RevertToSnapshot(snap)
+			require.Error(t, xerr)
+			require.True(t, xerr.Contains(xerrors.ErrInvalidSnapshot))
+		})
+	})
+
+	t.Run("negative revision", func(t *testing.T) {
+		ledger := newMutableLedgerForSnapshotIdentityTest(t)
+		snap := ledger.Snapshot()
+		snap.revision = -1
+
+		require.NotPanics(t, func() {
+			xerr := ledger.RevertToSnapshot(snap)
+			require.Error(t, xerr)
+			require.True(t, xerr.Contains(xerrors.ErrInvalidSnapshot))
+		})
+	})
+}
+
+func TestMutableLedger_SnapshotLifecycle(t *testing.T) {
+	t.Run("inner then outer revert", func(t *testing.T) {
+		ledger := newMutableLedgerForSnapshotIdentityTest(t)
+		key := newItem(601, "").Key()
+
+		require.NoError(t, ledger.Set(key, newItem(601, "base")))
+		outer := ledger.Snapshot()
+		require.NoError(t, ledger.Set(key, newItem(601, "outer")))
+		inner := ledger.Snapshot()
+		require.NoError(t, ledger.Set(key, newItem(601, "inner")))
+
+		require.NoError(t, ledger.RevertToSnapshot(inner))
+		requireSnapshotItemData(t, ledger, key, "outer")
+		require.NoError(t, ledger.RevertToSnapshot(outer))
+		requireSnapshotItemData(t, ledger, key, "base")
+	})
+
+	t.Run("outer then inner revert is rejected while out of range", func(t *testing.T) {
+		ledger := newMutableLedgerForSnapshotIdentityTest(t)
+		key := newItem(602, "").Key()
+
+		outer := ledger.Snapshot()
+		require.NoError(t, ledger.Set(key, newItem(602, "outer")))
+		inner := ledger.Snapshot()
+		require.NoError(t, ledger.Set(key, newItem(602, "inner")))
+
+		require.NoError(t, ledger.RevertToSnapshot(outer))
+		xerr := ledger.RevertToSnapshot(inner)
+		require.Error(t, xerr)
+		require.True(t, xerr.Contains(xerrors.ErrInvalidSnapshot))
+	})
+
+	t.Run("same snapshot can be reused as no-op", func(t *testing.T) {
+		ledger := newMutableLedgerForSnapshotIdentityTest(t)
+		key := newItem(603, "").Key()
+
+		snap := ledger.Snapshot()
+		require.NoError(t, ledger.Set(key, newItem(603, "created")))
+		require.NoError(t, ledger.RevertToSnapshot(snap))
+		require.NoError(t, ledger.RevertToSnapshot(snap))
+
+		_, xerr := ledger.Get(key)
+		require.Error(t, xerr)
+		require.True(t, xerr.Contains(xerrors.ErrNotFoundResult))
+	})
+
+	t.Run("old marker is valid when revision position is reused", func(t *testing.T) {
+		ledger := newMutableLedgerForSnapshotIdentityTest(t)
+		firstKey := newItem(604, "").Key()
+		secondKey := newItem(605, "").Key()
+
+		outer := ledger.Snapshot()
+		require.NoError(t, ledger.Set(firstKey, newItem(604, "first")))
+		oldInner := ledger.Snapshot()
+		require.NoError(t, ledger.RevertToSnapshot(outer))
+
+		require.NoError(t, ledger.Set(secondKey, newItem(605, "second")))
+		require.Equal(t, oldInner.revision, ledger.Snapshot().revision)
+		require.NoError(t, ledger.RevertToSnapshot(oldInner))
+		requireSnapshotItemData(t, ledger, secondKey, "second")
+	})
+}
+
+func TestMutableLedger_RevertToSnapshotInvalidatesCachedObjects(t *testing.T) {
+	ledger := newMutableLedgerForSnapshotIdentityTest(t)
+	key := newItem(606, "").Key()
+
+	require.NoError(t, ledger.Set(key, newItem(606, "persisted")))
+	_, _, xerr := ledger.Commit()
+	require.NoError(t, xerr)
+
+	cached, xerr := ledger.Get(key)
+	require.NoError(t, xerr)
+	snap := ledger.Snapshot()
+
+	cached.(*Item).data = "mutated-without-set"
+	require.Equal(t, "mutated-without-set", cached.(*Item).data)
+
+	require.NoError(t, ledger.RevertToSnapshot(snap))
+
+	reloaded, xerr := ledger.Get(key)
+	require.NoError(t, xerr)
+	require.Equal(t, "persisted", reloaded.(*Item).data)
+	require.NotSame(t, cached, reloaded)
+}
+
+func TestMutableLedger_RevertToSnapshotReturnsFatalErrorOnIAVLFailure(t *testing.T) {
+	t.Run("set failure", func(t *testing.T) {
+		ledger, failingDB := newMutableLedgerWithFailingIAVLReads(t)
+		key := newItem(901, "").Key()
+		snap := ledger.Snapshot()
+		ledger.revisions.set(key, []byte("old-value"))
+		ledger.cachedObjs[string(key)] = newItem(901, "cached")
+		revisionCount := len(ledger.revisions.revs)
+
+		failingDB.failReads = true
+		xerr := ledger.RevertToSnapshot(snap)
+
+		require.Error(t, xerr)
+		require.True(t, xerr.Contains(xerrors.ErrFatalLedger))
+		require.Contains(t, xerr.Error(), "revert snapshot set failed")
+		require.Empty(t, ledger.cachedObjs)
+		require.Len(t, ledger.revisions.revs, revisionCount)
+	})
+
+	t.Run("remove failure", func(t *testing.T) {
+		ledger, failingDB := newMutableLedgerWithFailingIAVLReads(t)
+		key := newItem(902, "").Key()
+		snap := ledger.Snapshot()
+		ledger.revisions.set(key, nil)
+		ledger.cachedObjs[string(key)] = newItem(902, "cached")
+		revisionCount := len(ledger.revisions.revs)
+
+		failingDB.failReads = true
+		xerr := ledger.RevertToSnapshot(snap)
+
+		require.Error(t, xerr)
+		require.True(t, xerr.Contains(xerrors.ErrFatalLedger))
+		require.Contains(t, xerr.Error(), "revert snapshot remove failed")
+		require.Empty(t, ledger.cachedObjs)
+		require.Len(t, ledger.revisions.revs, revisionCount)
+	})
+}
+
+func requireSnapshotItemData(t *testing.T, ledger IGettable, key LedgerKey, want string) {
+	t.Helper()
+
+	item, xerr := ledger.Get(key)
+	require.NoError(t, xerr)
+	require.Equal(t, want, item.(*Item).data)
+}
+
+func newMutableLedgerForSnapshotIdentityTest(t *testing.T) *MutableLedger {
+	t.Helper()
+
+	ledger, xerr := NewMutableLedger("ledger_test", t.TempDir(), 100, func(key LedgerKey) ILedgerItem {
+		return &Item{}
+	}, log.NewNopLogger())
+	require.NoError(t, xerr)
+	t.Cleanup(func() {
+		require.NoError(t, ledger.Close())
+	})
+	return ledger
+}
+
+type failingReadDB struct {
+	dbm.DB
+	failReads bool
+}
+
+func (db *failingReadDB) Get(key []byte) ([]byte, error) {
+	if db.failReads {
+		return nil, errors.New("injected IAVL read failure")
+	}
+	return db.DB.Get(key)
+}
+
+func newMutableLedgerWithFailingIAVLReads(t *testing.T) (*MutableLedger, *failingReadDB) {
+	t.Helper()
+
+	baseDB := dbm.NewMemDB()
+	sourceTree := iavl.NewMutableTree(baseDB, 0, true, iavl.NewNopLogger())
+	for i := 900; i < 904; i++ {
+		_, err := sourceTree.Set(newItem(i, "").Key(), []byte(fmt.Sprintf("value-%d", i)))
+		require.NoError(t, err)
+	}
+	_, version, err := sourceTree.SaveVersion()
+	require.NoError(t, err)
+
+	failingDB := &failingReadDB{DB: baseDB}
+	tree := iavl.NewMutableTree(failingDB, 0, true, iavl.NewNopLogger())
+	_, err = tree.LoadVersion(version)
+	require.NoError(t, err)
+
+	return &MutableLedger{
+		db:         failingDB,
+		tree:       tree,
+		revisions:  newSnapshotList[[]byte](),
+		cachedObjs: make(map[string]ILedgerItem),
+		newItemFor: func(key LedgerKey) ILedgerItem { return &Item{} },
+		cacheSize:  0,
+		logger:     log.NewNopLogger(),
+	}, failingDB
 }
 
 type Item struct {

--- a/ledger/v1/revision_list.go
+++ b/ledger/v1/revision_list.go
@@ -1,17 +1,29 @@
 package v1
 
+import (
+	"sync/atomic"
+
+	"github.com/beatoz/beatoz-go/types/xerrors"
+)
+
 type kvPair[T any] struct {
 	key []byte
 	val T
 }
 
 type revisionList[T any] struct {
-	revs []*kvPair[T]
+	revs       []*kvPair[T]
+	ledgerID   uint64
+	generation uint64
 }
+
+var nextLedgerID uint64
 
 func newSnapshotList[T any]() *revisionList[T] {
 	return &revisionList[T]{
-		revs: make([]*kvPair[T], 0),
+		revs:       make([]*kvPair[T], 0),
+		ledgerID:   atomic.AddUint64(&nextLedgerID, 1),
+		generation: 1,
 	}
 }
 func (revlist *revisionList[T]) set(key []byte, val T) {
@@ -21,16 +33,46 @@ func (revlist *revisionList[T]) set(key []byte, val T) {
 	})
 }
 
-func (revlist revisionList[T]) snapshot() int {
-	return len(revlist.revs)
+func (revlist revisionList[T]) snapshot() Snapshot {
+	return Snapshot{
+		ledgerID:   revlist.ledgerID,
+		generation: revlist.generation,
+		revision:   len(revlist.revs),
+	}
 }
 
-func (revlist *revisionList[T]) revert(snap int) {
-	revlist.revs = revlist.revs[:snap]
+func (revlist revisionList[T]) validateSnapshot(snap Snapshot) xerrors.XError {
+	if snap.ledgerID != revlist.ledgerID {
+		return xerrors.ErrInvalidSnapshot.Wrapf(
+			"ledger ID mismatch: snapshot=%d, ledger=%d",
+			snap.ledgerID,
+			revlist.ledgerID,
+		)
+	}
+	if snap.generation != revlist.generation {
+		return xerrors.ErrInvalidSnapshot.Wrapf(
+			"generation mismatch: snapshot=%d, ledger=%d",
+			snap.generation,
+			revlist.generation,
+		)
+	}
+	if snap.revision < 0 || snap.revision > len(revlist.revs) {
+		return xerrors.ErrInvalidSnapshot.Wrapf(
+			"revision out of range: snapshot=%d, revisions=%d",
+			snap.revision,
+			len(revlist.revs),
+		)
+	}
+	return nil
 }
 
-func (revlist revisionList[T]) reset() {
+func (revlist *revisionList[T]) revert(snap Snapshot) {
+	revlist.revs = revlist.revs[:snap.revision]
+}
+
+func (revlist *revisionList[T]) reset() {
 	revlist.revs = revlist.revs[:0]
+	revlist.generation++
 }
 
 func (revlist revisionList[T]) iterate(cb func(idx int, kv *kvPair[T]) bool) {

--- a/ledger/v1/state_ledger.go
+++ b/ledger/v1/state_ledger.go
@@ -94,14 +94,14 @@ func (ledger *StateLedger) Del(key LedgerKey, exec bool) xerrors.XError {
 	return nil
 }
 
-func (ledger *StateLedger) Snapshot(exec bool) int {
+func (ledger *StateLedger) Snapshot(exec bool) Snapshot {
 	ledger.mtx.RLock()
 	defer ledger.mtx.RUnlock()
 
 	return ledger.getLedger(exec).Snapshot()
 }
 
-func (ledger *StateLedger) RevertToSnapshot(snap int, exec bool) xerrors.XError {
+func (ledger *StateLedger) RevertToSnapshot(snap Snapshot, exec bool) xerrors.XError {
 	ledger.mtx.RLock()
 	defer ledger.mtx.RUnlock()
 

--- a/ledger/v1/state_ledger_test.go
+++ b/ledger/v1/state_ledger_test.go
@@ -1,0 +1,81 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/beatoz/beatoz-go/types/xerrors"
+	"github.com/stretchr/testify/require"
+	"github.com/tendermint/tendermint/libs/log"
+)
+
+func TestStateLedger_SnapshotDelegatesByExecMode(t *testing.T) {
+	ledger, xerr := NewStateLedger("state_ledger_test", t.TempDir(), 100, func(key LedgerKey) ILedgerItem {
+		return &Item{}
+	}, log.NewNopLogger())
+	require.NoError(t, xerr)
+	t.Cleanup(func() {
+		require.NoError(t, ledger.Close())
+	})
+
+	require.NoError(t, ledger.Set(newItem(800, "").Key(), newItem(800, "base"), true))
+	_, _, xerr = ledger.Commit()
+	require.NoError(t, xerr)
+
+	execKey := newItem(801, "").Key()
+	simulationKey := newItem(802, "").Key()
+	execSnap := ledger.Snapshot(true)
+	simulationSnap := ledger.Snapshot(false)
+
+	require.NoError(t, ledger.Set(execKey, newItem(801, "exec"), true))
+	require.NoError(t, ledger.Set(simulationKey, newItem(802, "simulation"), false))
+
+	require.NoError(t, ledger.RevertToSnapshot(execSnap, true))
+	_, xerr = ledger.Get(execKey, true)
+	require.Error(t, xerr)
+	require.True(t, xerr.Contains(xerrors.ErrNotFoundResult))
+	requireSnapshotItemDataFromStateLedger(t, ledger, simulationKey, "simulation", false)
+
+	require.NoError(t, ledger.RevertToSnapshot(simulationSnap, false))
+	_, xerr = ledger.Get(simulationKey, false)
+	require.Error(t, xerr)
+	require.True(t, xerr.Contains(xerrors.ErrNotFoundResult))
+}
+
+func TestStateLedger_RejectsSnapshotFromOtherExecMode(t *testing.T) {
+	ledger, xerr := NewStateLedger("state_ledger_test", t.TempDir(), 100, func(key LedgerKey) ILedgerItem {
+		return &Item{}
+	}, log.NewNopLogger())
+	require.NoError(t, xerr)
+	t.Cleanup(func() {
+		require.NoError(t, ledger.Close())
+	})
+
+	require.NoError(t, ledger.Set(newItem(810, "").Key(), newItem(810, "base"), true))
+	_, _, xerr = ledger.Commit()
+	require.NoError(t, xerr)
+
+	execSnap := ledger.Snapshot(true)
+	simulationSnap := ledger.Snapshot(false)
+
+	xerr = ledger.RevertToSnapshot(execSnap, false)
+	require.Error(t, xerr)
+	require.True(t, xerr.Contains(xerrors.ErrInvalidSnapshot))
+
+	xerr = ledger.RevertToSnapshot(simulationSnap, true)
+	require.Error(t, xerr)
+	require.True(t, xerr.Contains(xerrors.ErrInvalidSnapshot))
+}
+
+func requireSnapshotItemDataFromStateLedger(
+	t *testing.T,
+	ledger *StateLedger,
+	key LedgerKey,
+	want string,
+	exec bool,
+) {
+	t.Helper()
+
+	item, xerr := ledger.Get(key, exec)
+	require.NoError(t, xerr)
+	require.Equal(t, want, item.(*Item).data)
+}

--- a/ledger/v1/types.go
+++ b/ledger/v1/types.go
@@ -10,6 +10,14 @@ import (
 type FuncNewItemFor func(LedgerKey) ILedgerItem
 type FuncIterate func(LedgerKey, ILedgerItem) xerrors.XError
 
+// Snapshot is an opaque handle to a ledger revision position.
+// Its lifecycle and validity are managed by the ledger that issued it.
+type Snapshot struct {
+	ledgerID   uint64
+	generation uint64
+	revision   int
+}
+
 type IGettable interface {
 	Get(LedgerKey) (ILedgerItem, xerrors.XError)
 	Iterate(FuncIterate) xerrors.XError
@@ -19,8 +27,8 @@ type IGettable interface {
 type ISettable interface {
 	Set(LedgerKey, ILedgerItem) xerrors.XError
 	Del(LedgerKey) xerrors.XError
-	Snapshot() int
-	RevertToSnapshot(int) xerrors.XError
+	Snapshot() Snapshot
+	RevertToSnapshot(Snapshot) xerrors.XError
 }
 
 type ICommittable interface {
@@ -47,8 +55,8 @@ type IStateLedger interface {
 	Iterate(FuncIterate, bool) xerrors.XError
 	Seek([]byte, bool, FuncIterate, bool) xerrors.XError
 	Set(LedgerKey, ILedgerItem, bool) xerrors.XError
-	Snapshot(bool) int
-	RevertToSnapshot(int, bool) xerrors.XError
+	Snapshot(bool) Snapshot
+	RevertToSnapshot(Snapshot, bool) xerrors.XError
 	Del(LedgerKey, bool) xerrors.XError
 	Commit() ([]byte, int64, xerrors.XError)
 	Close() xerrors.XError

--- a/types/xerrors/xerror.go
+++ b/types/xerrors/xerror.go
@@ -81,6 +81,8 @@ var (
 	ErrNotVotingPeriod       = NewOrdinary("not voting period")
 	ErrDuplicatedKey         = NewOrdinary("already existed key")
 	ErrInvalidWeight         = NewOrdinary("invalid weight")
+	ErrInvalidSnapshot       = NewOrdinary("invalid ledger snapshot")
+	ErrFatalLedger           = NewOrdinary("fatal ledger error")
 )
 
 type XError interface {

--- a/types/xerrors/xerror_test.go
+++ b/types/xerrors/xerror_test.go
@@ -36,6 +36,12 @@ func Test_Contains(t *testing.T) {
 	require.False(t, xerr1.Contains(xerrNotContained))
 }
 
+func Test_FatalLedgerErrorCanBeClassified(t *testing.T) {
+	xerr := ErrFatalLedger.Wrap(errors.New("revert snapshot set failed"))
+
+	require.True(t, xerr.Contains(ErrFatalLedger))
+}
+
 func Test_Equal(t *testing.T) {
 	xerr := ErrNotFoundResult
 	require.Equal(t, ErrNotFoundResult, xerr)


### PR DESCRIPTION
# Harden Ledger Snapshot and Rollback Handling

## Summary

This PR hardens the `ledger/v1` snapshot and rollback implementation before it is used as the transaction rollback boundary.

Previously, snapshots were represented only by revision indexes. Revision history was not reset correctly after commit, invalid or stale snapshots could panic or target the wrong history, cached objects could retain uncommitted mutations after rollback, and `MemLedger` could not restore deletion of committed items.

The specific issue addressed by this PR is tracked in [BG-598](https://beatoz.atlassian.net/jira/software/projects/BG/boards/82?selectedIssue=BG-598).
## Changes

- Replace integer snapshot indexes with opaque snapshot handles containing ledger identity, generation, and revision position.
- Reject zero-value, foreign, stale, negative, and out-of-range snapshots with `ErrInvalidSnapshot`.
- Reset revision history correctly after commit and invalidate snapshots from earlier generations.
- Preserve the selected snapshot lifecycle policy, including reusable snapshots and revision-position reuse.
- Clear `MutableLedger` object caches before rollback so subsequent reads reload reverted state.
- Restore committed items deleted through `MemLedger` and avoid duplicate revisions for repeated or missing-item deletion.
- Classify IAVL failures during rollback as `ErrFatalLedger`.
- Keep revision history and clear cached objects when a rollback fails.
- Verify that `StateLedger` delegates snapshots and rollback to the correct `exec=true` or `exec=false` ledger.
- Add regression coverage for snapshot validation, lifecycle, cache invalidation, committed-item deletion, and IAVL rollback failures.

## Changed Files

- `ledger/v1/types.go`: introduces the opaque `Snapshot` type and updates ledger interfaces.
- `ledger/v1/revision_list.go`: adds ledger identity, generation tracking, snapshot validation, and correct revision reset behavior.
- `ledger/v1/mutable_ledger.go`: validates snapshots, invalidates caches, and returns fatal ledger errors for IAVL rollback failures.
- `ledger/v1/mem_ledger.go`: validates snapshots and records committed values before deletion.
- `ledger/v1/state_ledger.go`: updates snapshot and rollback delegation to use the new snapshot type.
- `ledger/v1/mutable_ledger_test.go`: adds revision lifecycle, invalid snapshot, cache rollback, and IAVL failure coverage.
- `ledger/v1/mem_ledger_test.go`: adds invalid snapshot, committed deletion, duplicate deletion, and lifecycle coverage.
- `ledger/v1/state_ledger_test.go`: adds execution-mode delegation and cross-mode snapshot rejection coverage.
- `types/xerrors/xerror.go`: adds `ErrInvalidSnapshot` and `ErrFatalLedger`.
- `types/xerrors/xerror_test.go`: verifies fatal ledger error classification.

## Test

```bash
go test ./ledger/v1 -count=1
go test -race ./ledger/v1 -count=1
```

Result:

```text
ok  	github.com/beatoz/beatoz-go/ledger/v1	1.249s
ok  	github.com/beatoz/beatoz-go/ledger/v1	2.845s
```
