### PR TITLE
Prevent Governance Parameter JSON Unmarshal Panic

### DIFF
--- a/ctrlers/types/gov_params.go
+++ b/ctrlers/types/gov_params.go
@@ -3,6 +3,7 @@ package types
 import (
 	"encoding/base64"
 	"encoding/hex"
+	"fmt"
 	"reflect"
 	"sync"
 
@@ -137,12 +138,25 @@ func (govParams *GovParams) UnmarshalJSON(d []byte) error {
 	}
 
 	for k, v := range tmp {
-		if k == "maxTotalSupply" || k == "gasPrice" {
-			tmp[k] = base64.StdEncoding.EncodeToString(uint256.MustFromDecimal(v.(string)).Bytes())
-		} else if k == "deadAddress" || k == "rewardPoolAddress" {
-			_v, err := hex.DecodeString(v.(string))
+		switch k {
+		case "maxTotalSupply", "gasPrice", "deadAddress", "rewardPoolAddress":
+			strValue, ok := v.(string)
+			if !ok {
+				return fmt.Errorf("invalid %s: expected string", k)
+			}
+
+			if k == "maxTotalSupply" || k == "gasPrice" {
+				_v, err := uint256.FromDecimal(strValue)
+				if err != nil {
+					return fmt.Errorf("invalid %s: %w", k, err)
+				}
+				tmp[k] = base64.StdEncoding.EncodeToString(_v.Bytes())
+				continue
+			}
+
+			_v, err := hex.DecodeString(strValue)
 			if err != nil {
-				return err
+				return fmt.Errorf("invalid %s: %w", k, err)
 			}
 			tmp[k] = base64.StdEncoding.EncodeToString(_v)
 		}

--- a/ctrlers/types/gov_params_test.go
+++ b/ctrlers/types/gov_params_test.go
@@ -37,3 +37,61 @@ func Test_JsonCodec(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, jz, jz2)
 }
+
+func TestGovParamsUnmarshalError(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		errField string
+	}{
+		{
+			name:     "gas price type",
+			input:    `{"gasPrice": 1}`,
+			errField: "gasPrice",
+		},
+		{
+			name:     "gas price value",
+			input:    `{"gasPrice": "not-a-number"}`,
+			errField: "gasPrice",
+		},
+		{
+			name:     "total supply type",
+			input:    `{"maxTotalSupply": 1}`,
+			errField: "maxTotalSupply",
+		},
+		{
+			name:     "total supply value",
+			input:    `{"maxTotalSupply": "not-a-number"}`,
+			errField: "maxTotalSupply",
+		},
+		{
+			name:     "dead address type",
+			input:    `{"deadAddress": 1}`,
+			errField: "deadAddress",
+		},
+		{
+			name:     "dead address value",
+			input:    `{"deadAddress": "not-hex"}`,
+			errField: "deadAddress",
+		},
+		{
+			name:     "reward address type",
+			input:    `{"rewardPoolAddress": 1}`,
+			errField: "rewardPoolAddress",
+		},
+		{
+			name:     "reward address value",
+			input:    `{"rewardPoolAddress": "not-hex"}`,
+			errField: "rewardPoolAddress",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := &GovParams{}
+			err := jsonx.Unmarshal([]byte(tt.input), params)
+			require.Error(t, err)
+			require.ErrorContains(t, err, tt.errField)
+		})
+	}
+}


### PR DESCRIPTION
# Prevent Governance Parameter JSON Unmarshal Panic

## Summary

This PR prevents malformed governance parameter JSON from causing a panic during `GovParams.UnmarshalJSON`.

Previously, special governance parameter fields were converted using unchecked string type assertions and `uint256.MustFromDecimal`. A non-string JSON value or invalid decimal string could therefore panic before the caller could handle the decode failure, potentially terminating a validator process.

The specific issue addressed by this PR is tracked in [BG-599](https://beatoz.atlassian.net/jira/software/projects/BG/boards/82?selectedIssue=BG-599).

## Changes

- Replace unchecked string type assertions with checked assertions that return an error.
- Replace `uint256.MustFromDecimal` with the error-returning `uint256.FromDecimal`.
- Return field-specific errors for invalid decimal and hexadecimal values.
- Preserve the existing controller error-handling path by returning unmarshal errors instead of panicking.
- Add regression tests for invalid types and values in `gasPrice`, `maxTotalSupply`, `deadAddress`, and `rewardPoolAddress`.

## Changed Files

- `ctrlers/types/gov_params.go`: converts governance parameter JSON decoding panics into errors.
- `ctrlers/types/gov_params_test.go`: adds malformed special-field unmarshal coverage.

## Test

```bash
go test ./ctrlers/types
```

Result:

```text
ok  	github.com/beatoz/beatoz-go/ctrlers/types	0.775s
```
