### PR TITLE
Prevent Additional Supply Underflow in gov proposal

### DIFF
--- a/ctrlers/gov/1_proposal_test.go
+++ b/ctrlers/gov/1_proposal_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/beatoz/beatoz-go/types"
 	"github.com/beatoz/beatoz-go/types/xerrors"
 	"github.com/beatoz/beatoz-sdk-go/web3"
+	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 )
 
@@ -132,6 +133,40 @@ func TestProposalDuplicate(t *testing.T) {
 	for i, c := range cases2 {
 		require.Error(t, xerrors.ErrDuplicatedKey, runCase(c), "index", i)
 	}
+}
+
+func TestInvalidMaxSupply(t *testing.T) {
+	newGovParams := &ctrlertypes.GovParams{}
+	newGovParams.SetValue(func(v *ctrlertypes.GovParamsProto) {
+		v.XMaxTotalSupply = uint256.NewInt(99).Bytes()
+	})
+	bzOpt, err := jsonx.Marshal(newGovParams)
+	require.NoError(t, err)
+
+	tx := web3.NewTrxProposal(
+		vpowMock.PickAddress(vpowMock.ValCnt-1),
+		types.ZeroAddress(),
+		200,
+		defMinGas,
+		defGasPrice,
+		"max supply below current supply",
+		10,
+		govCtrler.MinVotingPeriodBlocks(),
+		10+govCtrler.MinVotingPeriodBlocks()+govCtrler.LazyApplyingBlocks(),
+		proposal.PROPOSAL_GOVPARAMS,
+		bzOpt,
+	)
+	require.NoError(t, signTrx(tx, vpowMock.PickAddress(vpowMock.ValCnt-1), config.ChainIdHex()))
+
+	txctx := makeTrxCtx(tx, 1, true)
+	txctx.SupplyHandler = &proposalSupplyHandlerStub{
+		totalSupply: uint256.NewInt(100),
+	}
+
+	xerr := govCtrler.ValidateTrx(txctx)
+	require.Error(t, xerr)
+	require.True(t, xerr.Contains(xerrors.ErrInvalidTrxPayloadParams), xerr)
+	require.Contains(t, xerr.Error(), "maxTotalSupply")
 }
 
 func TestOverflowBlockHeight(t *testing.T) {

--- a/ctrlers/gov/ctrler.go
+++ b/ctrlers/gov/ctrler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/beatoz/beatoz-go/types"
 	abytes "github.com/beatoz/beatoz-go/types/bytes"
 	"github.com/beatoz/beatoz-go/types/xerrors"
+	"github.com/holiman/uint256"
 	"github.com/tendermint/tendermint/libs/log"
 	"sync"
 )
@@ -74,6 +75,14 @@ func (ctrler *GovCtrler) InitLedger(req interface{}) xerrors.XError {
 }
 
 func (ctrler *GovCtrler) ValidateTrx(ctx *ctrlertypes.TrxContext) xerrors.XError {
+	var currentTotalSupply *uint256.Int
+	if ctx.Tx.GetType() == ctrlertypes.TRX_PROPOSAL {
+		txpayload, ok := ctx.Tx.Payload.(*ctrlertypes.TrxPayloadProposal)
+		if ok && txpayload.OptType == proposal.PROPOSAL_GOVPARAMS {
+			currentTotalSupply = ctx.SupplyHandler.TotalSupply()
+		}
+	}
+
 	ctrler.mtx.RLock()
 	defer ctrler.mtx.RUnlock()
 
@@ -115,10 +124,14 @@ func (ctrler *GovCtrler) ValidateTrx(ctx *ctrlertypes.TrxContext) xerrors.XError
 		// check governance proposal consistency
 		if txpayload.OptType == proposal.PROPOSAL_GOVPARAMS {
 			//check options
-			checkGovParams := &ctrlertypes.GovParams{}
 			for _, option := range txpayload.Options {
+				checkGovParams := &ctrlertypes.GovParams{}
 				if err := jsonx.Unmarshal(option, checkGovParams); err != nil {
 					return xerrors.ErrInvalidTrxPayloadParams.Wrap(err)
+				}
+				ctrlertypes.MergeGovParams(&ctrler.GovParams, checkGovParams)
+				if xerr := checkGovParams.ValidateCurrentSupply(currentTotalSupply); xerr != nil {
+					return xerrors.ErrInvalidTrxPayloadParams.Wrap(xerr)
 				}
 			}
 		}

--- a/ctrlers/gov/ctrler_punish_test.go
+++ b/ctrlers/gov/ctrler_punish_test.go
@@ -15,6 +15,7 @@ import (
 	btztypes "github.com/beatoz/beatoz-go/types"
 	"github.com/beatoz/beatoz-go/types/bytes"
 	"github.com/beatoz/beatoz-sdk-go/web3"
+	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 	abcitypes "github.com/tendermint/tendermint/abci/types"
 	tmlog "github.com/tendermint/tendermint/libs/log"
@@ -33,7 +34,10 @@ func Test_Punish_By_BlockProcess(t *testing.T) {
 	require.NoError(t, xerr)
 	localGovCtrler.GovParams = *(types.DefaultGovParams())
 
-	bctx := mocks.InitBlockCtxWith(localCfg.ChainIdHex(), 1, localGovCtrler, acctMock, nil, nil, vpowMock)
+	supplyHandler := &proposalSupplyHandlerStub{
+		totalSupply: new(uint256.Int),
+	}
+	bctx := mocks.InitBlockCtxWith(localCfg.ChainIdHex(), 1, localGovCtrler, acctMock, nil, supplyHandler, vpowMock)
 	bctx.SetChainID(localCfg.ChainIdHex())
 
 	voterAddr := vpowMock.PickAddress(vpowMock.ValCnt - 1)

--- a/ctrlers/gov/helpers_test.go
+++ b/ctrlers/gov/helpers_test.go
@@ -6,11 +6,24 @@ import (
 	"github.com/beatoz/beatoz-go/ctrlers/mocks"
 	ctrlertypes "github.com/beatoz/beatoz-go/ctrlers/types"
 	"github.com/beatoz/beatoz-go/types/xerrors"
+	"github.com/holiman/uint256"
 )
+
+type proposalSupplyHandlerStub struct {
+	ctrlertypes.ISupplyHandler
+	totalSupply *uint256.Int
+}
+
+func (stub *proposalSupplyHandlerStub) TotalSupply() *uint256.Int {
+	return stub.totalSupply.Clone()
+}
 
 func makeTrxCtx(tx *ctrlertypes.Trx, height int64, exec bool) *ctrlertypes.TrxContext {
 
-	txctx, xerr := mocks.MakeTrxCtxWithTrx(tx, config.ChainIdHex(), height, time.Now(), exec, govCtrler, acctMock, nil, nil, vpowMock)
+	supplyHandler := &proposalSupplyHandlerStub{
+		totalSupply: new(uint256.Int),
+	}
+	txctx, xerr := mocks.MakeTrxCtxWithTrx(tx, config.ChainIdHex(), height, time.Now(), exec, govCtrler, acctMock, nil, supplyHandler, vpowMock)
 	if xerr != nil {
 		panic(xerr)
 	}

--- a/ctrlers/mocks/supply/ctrler_mock.go
+++ b/ctrlers/mocks/supply/ctrler_mock.go
@@ -43,6 +43,10 @@ func (mock *SupplyHandlerMock) RequestMint(bctx *types.BlockContext) {
 	panic("implement me")
 }
 
+func (mock *SupplyHandlerMock) TotalSupply() *uint256.Int {
+	return new(uint256.Int)
+}
+
 func (mock *SupplyHandlerMock) Burn(bctx *types.BlockContext, amt *uint256.Int) xerrors.XError {
 	return nil
 }

--- a/ctrlers/supply/ctrler.go
+++ b/ctrlers/supply/ctrler.go
@@ -73,6 +73,13 @@ func (ctrler *SupplyCtrler) InitLedger(req interface{}) xerrors.XError {
 	return nil
 }
 
+func (ctrler *SupplyCtrler) TotalSupply() *uint256.Int {
+	ctrler.mtx.RLock()
+	defer ctrler.mtx.RUnlock()
+
+	return ctrler.lastTotalSupply.GetTotalSupply()
+}
+
 func (ctrler *SupplyCtrler) ValidateTrx(ctx *ctrlertypes.TrxContext) xerrors.XError {
 	ctrler.mtx.Lock()
 	defer ctrler.mtx.Unlock()

--- a/ctrlers/supply/ctrler_mint.go
+++ b/ctrlers/supply/ctrler_mint.go
@@ -190,6 +190,10 @@ func heightYears(height int64, intval int32) fxnum.FxNum {
 // When FxNum uses `robaho/fixed` package, it supports only up to 7 decimal places.
 // Therefore, you must always use the shopspring/decimal package for final quantity calculations.
 func Sd(scaledHeight fxnum.FxNum, lastSupply, smax *uint256.Int, lambda int32, wa fxnum.FxNum) decimal.Decimal {
+	if smax.Cmp(lastSupply) <= 0 {
+		return decimal.Zero
+	}
+
 	return decimalSd(scaledHeight, lastSupply, smax, lambda, wa)
 }
 

--- a/ctrlers/supply/ctrler_mint_test.go
+++ b/ctrlers/supply/ctrler_mint_test.go
@@ -9,6 +9,7 @@ import (
 	vpowmock "github.com/beatoz/beatoz-go/ctrlers/mocks/vpower"
 	"github.com/beatoz/beatoz-go/ctrlers/types"
 	"github.com/beatoz/beatoz-go/ctrlers/vpower"
+	"github.com/beatoz/beatoz-go/libs/fxnum"
 	btztypes "github.com/beatoz/beatoz-go/types"
 	"github.com/beatoz/beatoz-go/types/bytes"
 	"github.com/beatoz/beatoz-sdk-go/web3"
@@ -16,6 +17,38 @@ import (
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/require"
 )
+
+func TestSdSupplyLimit(t *testing.T) {
+	tests := []struct {
+		name          string
+		currentSupply uint64
+		maxSupply     uint64
+	}{
+		{
+			name:          "equal",
+			currentSupply: 100,
+			maxSupply:     100,
+		},
+		{
+			name:          "over",
+			currentSupply: 101,
+			maxSupply:     100,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			addedSupply := Sd(
+				fxnum.FromInt(1),
+				uint256.NewInt(tt.currentSupply),
+				uint256.NewInt(tt.maxSupply),
+				100,
+				fxnum.FromInt(1),
+			)
+			require.True(t, addedSupply.IsZero(), addedSupply)
+		})
+	}
+}
 
 func Test_Mint(t *testing.T) {
 	require.NoError(t, os.RemoveAll(config.RootDir))

--- a/ctrlers/types/gov_params.go
+++ b/ctrlers/types/gov_params.go
@@ -241,6 +241,19 @@ func (govParams *GovParams) MaxTotalSupply() *uint256.Int {
 
 	return new(uint256.Int).SetBytes(govParams._v.XMaxTotalSupply)
 }
+
+func (govParams *GovParams) ValidateCurrentSupply(currentTotalSupply *uint256.Int) xerrors.XError {
+	maxTotalSupply := govParams.MaxTotalSupply()
+	if maxTotalSupply.Cmp(currentTotalSupply) < 0 {
+		return xerrors.NewOrdinary("invalid governance params").Wrapf(
+			"maxTotalSupply(%s) must be greater than or equal to currentTotalSupply(%s)",
+			maxTotalSupply.Dec(),
+			currentTotalSupply.Dec(),
+		)
+	}
+	return nil
+}
+
 func (govParams *GovParams) InflationWeightPermil() int32 {
 	govParams.mtx.RLock()
 	defer govParams.mtx.RUnlock()

--- a/ctrlers/types/gov_params_test.go
+++ b/ctrlers/types/gov_params_test.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"github.com/beatoz/beatoz-go/libs/jsonx"
+	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 	"reflect"
@@ -36,4 +37,47 @@ func Test_JsonCodec(t *testing.T) {
 	jz2, err := jsonx.MarshalIndent(govParams2, "", "  ")
 	require.NoError(t, err)
 	require.Equal(t, jz, jz2)
+}
+
+func TestValidateCurrentSupply(t *testing.T) {
+	tests := []struct {
+		name          string
+		maxSupply     uint64
+		currentSupply uint64
+		wantErr       bool
+	}{
+		{
+			name:          "max_supply_less_than_current_supply",
+			maxSupply:     99,
+			currentSupply: 100,
+			wantErr:       true,
+		},
+		{
+			name:          "max_supply_equal_to_current_supply",
+			maxSupply:     100,
+			currentSupply: 100,
+		},
+		{
+			name:          "max_supply_greater_than_current_supply",
+			maxSupply:     101,
+			currentSupply: 100,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := DefaultGovParams()
+			params.SetValue(func(v *GovParamsProto) {
+				v.XMaxTotalSupply = uint256.NewInt(tt.maxSupply).Bytes()
+			})
+
+			xerr := params.ValidateCurrentSupply(uint256.NewInt(tt.currentSupply))
+			if tt.wantErr {
+				require.Error(t, xerr)
+				require.Contains(t, xerr.Error(), "maxTotalSupply")
+				return
+			}
+			require.NoError(t, xerr)
+		})
+	}
 }

--- a/ctrlers/types/handlers.go
+++ b/ctrlers/types/handlers.go
@@ -110,6 +110,7 @@ type IVPowerHandler interface {
 type ISupplyHandler interface {
 	ITrxHandler
 	IBlockHandler
+	TotalSupply() *uint256.Int
 	RequestMint(bctx *BlockContext)
 	Burn(bctx *BlockContext, amt *uint256.Int) xerrors.XError
 }


### PR DESCRIPTION
# Prevent Additional Supply Underflow

## Summary

This PR prevents governance parameter proposals from setting `maxTotalSupply` below the current total supply and protects the additional supply calculation from unsigned integer underflow.

Previously, a positive `maxTotalSupply` could pass proposal validation even when it was lower than the current total supply. The subsequent `uint256` subtraction in `Sd()` could wrap around to a very large value and produce an abnormally large additional supply.

The specific issue addressed by this PR is tracked in [BG-600](https://beatoz.atlassian.net/jira/software/projects/BG/boards/82?selectedIssue=BG-600).

## Changes

- Add `GovParams.ValidateCurrentSupply()` to verify that `maxTotalSupply` is greater than or equal to the current total supply.
- Add `TotalSupply()` to `ISupplyHandler`.
- Implement a read-locked total supply getter in `SupplyCtrler`.
- Read the current total supply only when validating `PROPOSAL_GOVPARAMS`.
- Merge each governance proposal option with the current parameters before validating `maxTotalSupply`.
- Reject governance parameter proposals whose `maxTotalSupply` is below the current total supply.
- Return zero from `Sd()` when `maxTotalSupply` is equal to or below the current total supply.
- Add regression tests for proposal validation and additional supply calculation boundaries.

## Changed Files

- `ctrlers/types/gov_params.go`: adds current supply validation for `maxTotalSupply`.
- `ctrlers/types/gov_params_test.go`: adds validation coverage for lower, equal, and greater supply boundaries.
- `ctrlers/types/handlers.go`: adds `TotalSupply()` to `ISupplyHandler`.
- `ctrlers/supply/ctrler.go`: implements a read-locked total supply getter.
- `ctrlers/supply/ctrler_mint.go`: prevents unsigned subtraction when the supply limit has already been reached or exceeded.
- `ctrlers/supply/ctrler_mint_test.go`: adds `Sd()` boundary regression tests.
- `ctrlers/mocks/supply/ctrler_mock.go`: implements the new supply handler method.
- `ctrlers/gov/ctrler.go`: validates merged governance parameters against the current total supply.
- `ctrlers/gov/1_proposal_test.go`: verifies rejection of an invalid `maxTotalSupply` proposal.
- `ctrlers/gov/helpers_test.go`: provides a total supply stub for governance tests.
- `ctrlers/gov/ctrler_punish_test.go`: supplies the required supply handler dependency to the block process test.

## Test

```bash
go test ./ctrlers/types -run '^TestValidateCurrentSupply$' -count=1
go test ./ctrlers/gov -run '^TestInvalidMaxSupply$' -count=1
go test ./ctrlers/supply -run '^TestSdSupplyLimit$' -count=1
go test ./ctrlers/gov ./ctrlers/types ./ctrlers/supply -count=1
```

Result:

```text
ok  	github.com/beatoz/beatoz-go/ctrlers/gov
ok  	github.com/beatoz/beatoz-go/ctrlers/types
ok  	github.com/beatoz/beatoz-go/ctrlers/supply
```
