### PR TITLE
Harden Transaction, Governance Parameter, and Supply Validation 

### DIFF
--- a/ctrlers/gov/1_proposal_test.go
+++ b/ctrlers/gov/1_proposal_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/beatoz/beatoz-go/types"
 	"github.com/beatoz/beatoz-go/types/xerrors"
 	"github.com/beatoz/beatoz-sdk-go/web3"
+	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 )
 
@@ -132,6 +133,40 @@ func TestProposalDuplicate(t *testing.T) {
 	for i, c := range cases2 {
 		require.Error(t, xerrors.ErrDuplicatedKey, runCase(c), "index", i)
 	}
+}
+
+func TestInvalidMaxSupply(t *testing.T) {
+	newGovParams := &ctrlertypes.GovParams{}
+	newGovParams.SetValue(func(v *ctrlertypes.GovParamsProto) {
+		v.XMaxTotalSupply = uint256.NewInt(99).Bytes()
+	})
+	bzOpt, err := jsonx.Marshal(newGovParams)
+	require.NoError(t, err)
+
+	tx := web3.NewTrxProposal(
+		vpowMock.PickAddress(vpowMock.ValCnt-1),
+		types.ZeroAddress(),
+		200,
+		defMinGas,
+		defGasPrice,
+		"max supply below current supply",
+		10,
+		govCtrler.MinVotingPeriodBlocks(),
+		10+govCtrler.MinVotingPeriodBlocks()+govCtrler.LazyApplyingBlocks(),
+		proposal.PROPOSAL_GOVPARAMS,
+		bzOpt,
+	)
+	require.NoError(t, signTrx(tx, vpowMock.PickAddress(vpowMock.ValCnt-1), config.ChainIdHex()))
+
+	txctx := makeTrxCtx(tx, 1, true)
+	txctx.SupplyHandler = &proposalSupplyHandlerStub{
+		totalSupply: uint256.NewInt(100),
+	}
+
+	xerr := govCtrler.ValidateTrx(txctx)
+	require.Error(t, xerr)
+	require.True(t, xerr.Contains(xerrors.ErrInvalidTrxPayloadParams), xerr)
+	require.Contains(t, xerr.Error(), "maxTotalSupply")
 }
 
 func TestOverflowBlockHeight(t *testing.T) {

--- a/ctrlers/gov/1_proposal_test.go
+++ b/ctrlers/gov/1_proposal_test.go
@@ -134,6 +134,58 @@ func TestProposalDuplicate(t *testing.T) {
 	}
 }
 
+func TestInvalidGovParamsProposalValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*ctrlertypes.GovParamsProto)
+		wantMsg string
+	}{
+		{
+			name: "negative_max_validator_count",
+			mutate: func(v *ctrlertypes.GovParamsProto) {
+				v.MaxValidatorCnt = -1
+			},
+			wantMsg: "maxValidatorCnt",
+		},
+		{
+			name: "tx_fee_reward_rate_over_100",
+			mutate: func(v *ctrlertypes.GovParamsProto) {
+				v.TxFeeRewardRate = 200
+			},
+			wantMsg: "txFeeRewardRate",
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			newGovParams := &ctrlertypes.GovParams{}
+			newGovParams.SetValue(tt.mutate)
+			bzOpt, err := jsonx.Marshal(newGovParams)
+			require.NoError(t, err)
+
+			tx := web3.NewTrxProposal(
+				vpowMock.PickAddress(vpowMock.ValCnt-1),
+				types.ZeroAddress(),
+				int64(100+i),
+				defMinGas,
+				defGasPrice,
+				"invalid govparams proposal",
+				10,
+				govCtrler.MinVotingPeriodBlocks(),
+				10+govCtrler.MinVotingPeriodBlocks()+govCtrler.LazyApplyingBlocks(),
+				proposal.PROPOSAL_GOVPARAMS,
+				bzOpt,
+			)
+			require.NoError(t, signTrx(tx, vpowMock.PickAddress(vpowMock.ValCnt-1), config.ChainIdHex()))
+
+			xerr := runTrx(makeTrxCtx(tx, 1, true))
+			require.Error(t, xerr)
+			require.True(t, xerr.Contains(xerrors.ErrInvalidTrxPayloadParams), xerr)
+			require.Contains(t, xerr.Error(), tt.wantMsg)
+		})
+	}
+}
+
 func TestOverflowBlockHeight(t *testing.T) {
 	bzOpt, err := jsonx.Marshal(govParams0)
 	require.NoError(t, err)

--- a/ctrlers/gov/2_voting_test.go
+++ b/ctrlers/gov/2_voting_test.go
@@ -280,3 +280,43 @@ func TestApplyingProposal(t *testing.T) {
 	require.NotEqual(t, oriParams, govCtrler.GovParams)
 	require.True(t, govParams1.Equal(&govCtrler.GovParams))
 }
+
+func TestApplyInvalidGovParamsProposalRejected(t *testing.T) {
+	oriParams := govCtrler.GovParams
+	govCtrler.newGovParams = nil
+
+	invalidGovParams := &ctrlertypes.GovParams{}
+	invalidGovParams.SetValue(func(v *ctrlertypes.GovParamsProto) {
+		v.MaxValidatorCnt = -1
+	})
+	bzOpt, err := jsonx.Marshal(invalidGovParams)
+	require.NoError(t, err)
+
+	txHash := bytes.RandBytes(32)
+	applyHeight := int64(100)
+	prop := proposal.NewGovProposal(proposal.PROPOSAL_GOVPARAMS, txHash, 1, 1, 1, applyHeight)
+	prop.AddOption(bzOpt)
+	require.NotNil(t, prop.UpdateMajorOption())
+
+	frozenKey := v1.LedgerKeyFrozenProp(txHash)
+	require.NoError(t, govCtrler.govState.Set(frozenKey, prop, true))
+
+	bctx := &ctrlertypes.BlockContext{}
+	bctx.SetHeight(applyHeight)
+	evts, xerr := govCtrler.EndBlock(bctx)
+	require.NoError(t, xerr)
+	require.Nil(t, govCtrler.newGovParams)
+	require.True(t, oriParams.Equal(&govCtrler.GovParams))
+
+	require.Len(t, evts, 1)
+	require.Equal(t, "proposal", evts[0].Type)
+	require.Len(t, evts[0].Attributes, 1)
+	require.Equal(t, "rejected", string(evts[0].Attributes[0].Key))
+
+	_, _, xerr = govCtrler.Commit()
+	require.NoError(t, xerr)
+
+	frozenProp, xerr := govCtrler.govState.Get(frozenKey, false)
+	require.Equal(t, xerrors.ErrNotFoundResult, xerr)
+	require.Nil(t, frozenProp)
+}

--- a/ctrlers/gov/ctrler.go
+++ b/ctrlers/gov/ctrler.go
@@ -115,10 +115,14 @@ func (ctrler *GovCtrler) ValidateTrx(ctx *ctrlertypes.TrxContext) xerrors.XError
 		// check governance proposal consistency
 		if txpayload.OptType == proposal.PROPOSAL_GOVPARAMS {
 			//check options
-			checkGovParams := &ctrlertypes.GovParams{}
 			for _, option := range txpayload.Options {
+				checkGovParams := &ctrlertypes.GovParams{}
 				if err := jsonx.Unmarshal(option, checkGovParams); err != nil {
 					return xerrors.ErrInvalidTrxPayloadParams.Wrap(err)
+				}
+				ctrlertypes.MergeGovParams(&ctrler.GovParams, checkGovParams)
+				if xerr := checkGovParams.ValidateBasic(); xerr != nil {
+					return xerrors.ErrInvalidTrxPayloadParams.Wrap(xerr)
 				}
 			}
 		}
@@ -287,8 +291,9 @@ func (ctrler *GovCtrler) freezeProposals(height int64) ([]v1.LedgerKey, []v1.Led
 }
 
 // applyProposals is called from EndBlock
-func (ctrler *GovCtrler) applyProposals(height int64) ([]v1.LedgerKey, xerrors.XError) {
+func (ctrler *GovCtrler) applyProposals(height int64) ([]v1.LedgerKey, []v1.LedgerKey, xerrors.XError) {
 	var applied []v1.LedgerKey
+	var rejected []v1.LedgerKey
 
 	defer func() {
 		if ctrler.newGovParams != nil {
@@ -296,6 +301,10 @@ func (ctrler *GovCtrler) applyProposals(height int64) ([]v1.LedgerKey, xerrors.X
 		}
 
 		for _, k := range applied {
+			// remove
+			_ = ctrler.govState.Del(k, true)
+		}
+		for _, k := range rejected {
 			// remove
 			_ = ctrler.govState.Del(k, true)
 		}
@@ -310,6 +319,8 @@ func (ctrler *GovCtrler) applyProposals(height int64) ([]v1.LedgerKey, xerrors.X
 			if prop.MajorOption() == nil {
 				// not reachable.
 				ctrler.logger.Error("Apply proposal", "error", "major option is nil")
+				rejected = append(rejected, key)
+				return nil
 			}
 
 			switch prop.Header().PropType {
@@ -319,10 +330,16 @@ func (ctrler *GovCtrler) applyProposals(height int64) ([]v1.LedgerKey, xerrors.X
 				strOpt := string(prop.MajorOption().Option)
 				if err := jsonx.Unmarshal([]byte(strOpt), newGovParams); err != nil {
 					ctrler.logger.Error("Apply proposal", "error", err, "option", string(prop.MajorOption().Option))
-					return xerrors.From(err)
+					rejected = append(rejected, key)
+					return nil
 				}
 
 				ctrlertypes.MergeGovParams(&ctrler.GovParams, newGovParams)
+				if xerr := newGovParams.ValidateBasic(); xerr != nil {
+					ctrler.logger.Error("Apply proposal", "error", xerr, "option", string(prop.MajorOption().Option))
+					rejected = append(rejected, key)
+					return nil
+				}
 				ctrler.newGovParams = newGovParams
 			default:
 				ctrler.logger.Debug("Apply proposal", "key(txHash)", prop.Header().TxHash, "type", prop.Header().PropType)
@@ -334,7 +351,7 @@ func (ctrler *GovCtrler) applyProposals(height int64) ([]v1.LedgerKey, xerrors.X
 		return nil
 	}, true)
 
-	return applied, xerr
+	return applied, rejected, xerr
 }
 
 func (ctrler *GovCtrler) Close() xerrors.XError {

--- a/ctrlers/gov/ctrler.go
+++ b/ctrlers/gov/ctrler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/beatoz/beatoz-go/types"
 	abytes "github.com/beatoz/beatoz-go/types/bytes"
 	"github.com/beatoz/beatoz-go/types/xerrors"
+	"github.com/holiman/uint256"
 	"github.com/tendermint/tendermint/libs/log"
 	"sync"
 )
@@ -74,6 +75,14 @@ func (ctrler *GovCtrler) InitLedger(req interface{}) xerrors.XError {
 }
 
 func (ctrler *GovCtrler) ValidateTrx(ctx *ctrlertypes.TrxContext) xerrors.XError {
+	var currentTotalSupply *uint256.Int
+	if ctx.Tx.GetType() == ctrlertypes.TRX_PROPOSAL {
+		txpayload, ok := ctx.Tx.Payload.(*ctrlertypes.TrxPayloadProposal)
+		if ok && txpayload.OptType == proposal.PROPOSAL_GOVPARAMS {
+			currentTotalSupply = ctx.SupplyHandler.TotalSupply()
+		}
+	}
+
 	ctrler.mtx.RLock()
 	defer ctrler.mtx.RUnlock()
 
@@ -115,10 +124,14 @@ func (ctrler *GovCtrler) ValidateTrx(ctx *ctrlertypes.TrxContext) xerrors.XError
 		// check governance proposal consistency
 		if txpayload.OptType == proposal.PROPOSAL_GOVPARAMS {
 			//check options
-			checkGovParams := &ctrlertypes.GovParams{}
 			for _, option := range txpayload.Options {
+				checkGovParams := &ctrlertypes.GovParams{}
 				if err := jsonx.Unmarshal(option, checkGovParams); err != nil {
 					return xerrors.ErrInvalidTrxPayloadParams.Wrap(err)
+				}
+				ctrlertypes.MergeGovParams(&ctrler.GovParams, checkGovParams)
+				if xerr := checkGovParams.ValidateCurrentSupply(currentTotalSupply); xerr != nil {
+					return xerrors.ErrInvalidTrxPayloadParams.Wrap(xerr)
 				}
 			}
 		}

--- a/ctrlers/gov/ctrler_block.go
+++ b/ctrlers/gov/ctrler_block.go
@@ -49,7 +49,7 @@ func (ctrler *GovCtrler) EndBlock(ctx *types.BlockContext) ([]types2.Event, xerr
 		return nil, xerr
 	}
 
-	applied, xerr := ctrler.applyProposals(ctx.Height())
+	applied, rejected, xerr := ctrler.applyProposals(ctx.Height())
 	if xerr != nil {
 		return nil, xerr
 	}
@@ -75,6 +75,14 @@ func (ctrler *GovCtrler) EndBlock(ctx *types.BlockContext) ([]types2.Event, xerr
 			Type: "proposal",
 			Attributes: []types2.EventAttribute{
 				{Key: []byte("applied"), Value: []byte(hex.EncodeToString(v1.UnwrapKeyPrefix(k))), Index: true},
+			},
+		})
+	}
+	for _, k := range rejected {
+		evts = append(evts, types2.Event{
+			Type: "proposal",
+			Attributes: []types2.EventAttribute{
+				{Key: []byte("rejected"), Value: []byte(hex.EncodeToString(v1.UnwrapKeyPrefix(k))), Index: true},
 			},
 		})
 	}

--- a/ctrlers/gov/ctrler_punish_test.go
+++ b/ctrlers/gov/ctrler_punish_test.go
@@ -15,6 +15,7 @@ import (
 	btztypes "github.com/beatoz/beatoz-go/types"
 	"github.com/beatoz/beatoz-go/types/bytes"
 	"github.com/beatoz/beatoz-sdk-go/web3"
+	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 	abcitypes "github.com/tendermint/tendermint/abci/types"
 	tmlog "github.com/tendermint/tendermint/libs/log"
@@ -33,7 +34,10 @@ func Test_Punish_By_BlockProcess(t *testing.T) {
 	require.NoError(t, xerr)
 	localGovCtrler.GovParams = *(types.DefaultGovParams())
 
-	bctx := mocks.InitBlockCtxWith(localCfg.ChainIdHex(), 1, localGovCtrler, acctMock, nil, nil, vpowMock)
+	supplyHandler := &proposalSupplyHandlerStub{
+		totalSupply: new(uint256.Int),
+	}
+	bctx := mocks.InitBlockCtxWith(localCfg.ChainIdHex(), 1, localGovCtrler, acctMock, nil, supplyHandler, vpowMock)
 	bctx.SetChainID(localCfg.ChainIdHex())
 
 	voterAddr := vpowMock.PickAddress(vpowMock.ValCnt - 1)

--- a/ctrlers/gov/helpers_test.go
+++ b/ctrlers/gov/helpers_test.go
@@ -6,11 +6,24 @@ import (
 	"github.com/beatoz/beatoz-go/ctrlers/mocks"
 	ctrlertypes "github.com/beatoz/beatoz-go/ctrlers/types"
 	"github.com/beatoz/beatoz-go/types/xerrors"
+	"github.com/holiman/uint256"
 )
+
+type proposalSupplyHandlerStub struct {
+	ctrlertypes.ISupplyHandler
+	totalSupply *uint256.Int
+}
+
+func (stub *proposalSupplyHandlerStub) TotalSupply() *uint256.Int {
+	return stub.totalSupply.Clone()
+}
 
 func makeTrxCtx(tx *ctrlertypes.Trx, height int64, exec bool) *ctrlertypes.TrxContext {
 
-	txctx, xerr := mocks.MakeTrxCtxWithTrx(tx, config.ChainIdHex(), height, time.Now(), exec, govCtrler, acctMock, nil, nil, vpowMock)
+	supplyHandler := &proposalSupplyHandlerStub{
+		totalSupply: new(uint256.Int),
+	}
+	txctx, xerr := mocks.MakeTrxCtxWithTrx(tx, config.ChainIdHex(), height, time.Now(), exec, govCtrler, acctMock, nil, supplyHandler, vpowMock)
 	if xerr != nil {
 		panic(xerr)
 	}

--- a/ctrlers/mocks/supply/ctrler_mock.go
+++ b/ctrlers/mocks/supply/ctrler_mock.go
@@ -43,6 +43,10 @@ func (mock *SupplyHandlerMock) RequestMint(bctx *types.BlockContext) {
 	panic("implement me")
 }
 
+func (mock *SupplyHandlerMock) TotalSupply() *uint256.Int {
+	return new(uint256.Int)
+}
+
 func (mock *SupplyHandlerMock) Burn(bctx *types.BlockContext, amt *uint256.Int) xerrors.XError {
 	return nil
 }

--- a/ctrlers/supply/ctrler.go
+++ b/ctrlers/supply/ctrler.go
@@ -73,6 +73,13 @@ func (ctrler *SupplyCtrler) InitLedger(req interface{}) xerrors.XError {
 	return nil
 }
 
+func (ctrler *SupplyCtrler) TotalSupply() *uint256.Int {
+	ctrler.mtx.RLock()
+	defer ctrler.mtx.RUnlock()
+
+	return ctrler.lastTotalSupply.GetTotalSupply()
+}
+
 func (ctrler *SupplyCtrler) ValidateTrx(ctx *ctrlertypes.TrxContext) xerrors.XError {
 	ctrler.mtx.Lock()
 	defer ctrler.mtx.Unlock()

--- a/ctrlers/supply/ctrler_mint.go
+++ b/ctrlers/supply/ctrler_mint.go
@@ -190,6 +190,10 @@ func heightYears(height int64, intval int32) fxnum.FxNum {
 // When FxNum uses `robaho/fixed` package, it supports only up to 7 decimal places.
 // Therefore, you must always use the shopspring/decimal package for final quantity calculations.
 func Sd(scaledHeight fxnum.FxNum, lastSupply, smax *uint256.Int, lambda int32, wa fxnum.FxNum) decimal.Decimal {
+	if smax.Cmp(lastSupply) <= 0 {
+		return decimal.Zero
+	}
+
 	return decimalSd(scaledHeight, lastSupply, smax, lambda, wa)
 }
 

--- a/ctrlers/supply/ctrler_mint_test.go
+++ b/ctrlers/supply/ctrler_mint_test.go
@@ -9,6 +9,7 @@ import (
 	vpowmock "github.com/beatoz/beatoz-go/ctrlers/mocks/vpower"
 	"github.com/beatoz/beatoz-go/ctrlers/types"
 	"github.com/beatoz/beatoz-go/ctrlers/vpower"
+	"github.com/beatoz/beatoz-go/libs/fxnum"
 	btztypes "github.com/beatoz/beatoz-go/types"
 	"github.com/beatoz/beatoz-go/types/bytes"
 	"github.com/beatoz/beatoz-sdk-go/web3"
@@ -16,6 +17,38 @@ import (
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/require"
 )
+
+func TestSdSupplyLimit(t *testing.T) {
+	tests := []struct {
+		name          string
+		currentSupply uint64
+		maxSupply     uint64
+	}{
+		{
+			name:          "equal",
+			currentSupply: 100,
+			maxSupply:     100,
+		},
+		{
+			name:          "over",
+			currentSupply: 101,
+			maxSupply:     100,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			addedSupply := Sd(
+				fxnum.FromInt(1),
+				uint256.NewInt(tt.currentSupply),
+				uint256.NewInt(tt.maxSupply),
+				100,
+				fxnum.FromInt(1),
+			)
+			require.True(t, addedSupply.IsZero(), addedSupply)
+		})
+	}
+}
 
 func Test_Mint(t *testing.T) {
 	require.NoError(t, os.RemoveAll(config.RootDir))

--- a/ctrlers/types/gov_params.go
+++ b/ctrlers/types/gov_params.go
@@ -93,6 +93,115 @@ func (govParams *GovParams) Decode(k, v []byte) xerrors.XError {
 	return nil
 }
 
+func (govParams *GovParams) ValidateBasic() xerrors.XError {
+	govParams.mtx.RLock()
+	v := govParams._v
+	govParams.mtx.RUnlock()
+
+	if v.EmptyBlockIntervalSecs <= 0 {
+		return xerrors.NewOrdinary("invalid governance params").Wrapf("emptyBlockIntervalSecs must be positive")
+	}
+	if v.MaxValidatorCnt <= 0 {
+		return xerrors.NewOrdinary("invalid governance params").Wrapf("maxValidatorCnt must be positive")
+	}
+	if v.MinValidatorPower < 0 {
+		return xerrors.NewOrdinary("invalid governance params").Wrapf("minValidatorPower must be non-negative")
+	}
+	if v.MinDelegatorPower < 0 {
+		return xerrors.NewOrdinary("invalid governance params").Wrapf("minDelegatorPower must be non-negative")
+	}
+	if v.MaxValidatorsOfDelegator <= 0 {
+		return xerrors.NewOrdinary("invalid governance params").Wrapf("maxValidatorsOfDelegator must be positive")
+	}
+	if v.MaxDelegatorsOfValidator <= 0 {
+		return xerrors.NewOrdinary("invalid governance params").Wrapf("maxDelegatorsOfValidator must be positive")
+	}
+	if xerr := validatePercentRate("minSelfPowerRate", v.MinSelfPowerRate); xerr != nil {
+		return xerr
+	}
+	if xerr := validatePercentRate("maxUpdatablePowerRate", v.MaxUpdatablePowerRate); xerr != nil {
+		return xerr
+	}
+	if xerr := validatePercentRate("maxIndividualPowerRate", v.MaxIndividualPowerRate); xerr != nil {
+		return xerr
+	}
+	if v.MinBondingBlocks < 0 {
+		return xerrors.NewOrdinary("invalid governance params").Wrapf("minBondingBlocks must be non-negative")
+	}
+	if v.MinSignedBlocks < 0 {
+		return xerrors.NewOrdinary("invalid governance params").Wrapf("minSignedBlocks must be non-negative")
+	}
+	if v.LazyUnbondingBlocks < 0 {
+		return xerrors.NewOrdinary("invalid governance params").Wrapf("lazyUnbondingBlocks must be non-negative")
+	}
+	if new(uint256.Int).SetBytes(v.XMaxTotalSupply).IsZero() {
+		return xerrors.NewOrdinary("invalid governance params").Wrapf("maxTotalSupply must be positive")
+	}
+	if xerr := validatePermilRate("inflationWeightPermil", v.InflationWeightPermil); xerr != nil {
+		return xerr
+	}
+	if v.InflationCycleBlocks <= 0 {
+		return xerrors.NewOrdinary("invalid governance params").Wrapf("inflationCycleBlocks must be positive")
+	}
+	if xerr := validatePermilRate("bondingBlocksWeightPermil", v.BondingBlocksWeightPermil); xerr != nil {
+		return xerr
+	}
+	if v.RipeningBlocks < 0 {
+		return xerrors.NewOrdinary("invalid governance params").Wrapf("ripeningBlocks must be non-negative")
+	}
+	if len(v.XRewardPoolAddress) != types.AddrSize {
+		return xerrors.NewOrdinary("invalid governance params").Wrapf("rewardPoolAddress must be %d bytes", types.AddrSize)
+	}
+	if len(v.XDeadAddress) != types.AddrSize {
+		return xerrors.NewOrdinary("invalid governance params").Wrapf("deadAddress must be %d bytes", types.AddrSize)
+	}
+	if xerr := validatePercentRate("validatorRewardRate", v.ValidatorRewardRate); xerr != nil {
+		return xerr
+	}
+	if xerr := validatePercentRate("txFeeRewardRate", v.TxFeeRewardRate); xerr != nil {
+		return xerr
+	}
+	if xerr := validatePercentRate("slashRate", v.SlashRate); xerr != nil {
+		return xerr
+	}
+	if new(uint256.Int).SetBytes(v.XGasPrice).IsZero() {
+		return xerrors.NewOrdinary("invalid governance params").Wrapf("gasPrice must be positive")
+	}
+	if v.MinTrxGas <= 0 {
+		return xerrors.NewOrdinary("invalid governance params").Wrapf("minTrxGas must be positive")
+	}
+	if v.BlockSizeLimit <= 0 {
+		return xerrors.NewOrdinary("invalid governance params").Wrapf("blockSizeLimit must be positive")
+	}
+	if v.BlockGasLimit <= 0 {
+		return xerrors.NewOrdinary("invalid governance params").Wrapf("blockGasLimit must be positive")
+	}
+	if v.MinVotingPeriodBlocks <= 0 {
+		return xerrors.NewOrdinary("invalid governance params").Wrapf("minVotingPeriodBlocks must be positive")
+	}
+	if v.MaxVotingPeriodBlocks < v.MinVotingPeriodBlocks {
+		return xerrors.NewOrdinary("invalid governance params").Wrapf("maxVotingPeriodBlocks must be greater than or equal to minVotingPeriodBlocks")
+	}
+	if v.LazyApplyingBlocks < 0 {
+		return xerrors.NewOrdinary("invalid governance params").Wrapf("lazyApplyingBlocks must be non-negative")
+	}
+	return nil
+}
+
+func validatePercentRate(name string, rate int32) xerrors.XError {
+	if rate < 0 || rate > 100 {
+		return xerrors.NewOrdinary("invalid governance params").Wrapf("%s must be in [0, 100]", name)
+	}
+	return nil
+}
+
+func validatePermilRate(name string, rate int32) xerrors.XError {
+	if rate < 0 || rate > 1000 {
+		return xerrors.NewOrdinary("invalid governance params").Wrapf("%s must be in [0, 1000]", name)
+	}
+	return nil
+}
+
 func (govParams *GovParams) MarshalJSON() ([]byte, error) {
 	govParams.mtx.RLock()
 	defer govParams.mtx.RUnlock()

--- a/ctrlers/types/gov_params.go
+++ b/ctrlers/types/gov_params.go
@@ -241,6 +241,19 @@ func (govParams *GovParams) MaxTotalSupply() *uint256.Int {
 
 	return new(uint256.Int).SetBytes(govParams._v.XMaxTotalSupply)
 }
+
+func (govParams *GovParams) ValidateCurrentSupply(currentTotalSupply *uint256.Int) xerrors.XError {
+	maxTotalSupply := govParams.MaxTotalSupply()
+	if maxTotalSupply.Cmp(currentTotalSupply) < 0 {
+		return xerrors.NewOrdinary("invalid governance params").Wrapf(
+			"maxTotalSupply(%s) must be greater than or equal to currentTotalSupply(%s)",
+			maxTotalSupply.Dec(),
+			currentTotalSupply.Dec(),
+		)
+	}
+	return nil
+}
+
 func (govParams *GovParams) InflationWeightPermil() int32 {
 	govParams.mtx.RLock()
 	defer govParams.mtx.RUnlock()

--- a/ctrlers/types/gov_params.go
+++ b/ctrlers/types/gov_params.go
@@ -3,6 +3,7 @@ package types
 import (
 	"encoding/base64"
 	"encoding/hex"
+	"fmt"
 	"reflect"
 	"sync"
 
@@ -137,12 +138,25 @@ func (govParams *GovParams) UnmarshalJSON(d []byte) error {
 	}
 
 	for k, v := range tmp {
-		if k == "maxTotalSupply" || k == "gasPrice" {
-			tmp[k] = base64.StdEncoding.EncodeToString(uint256.MustFromDecimal(v.(string)).Bytes())
-		} else if k == "deadAddress" || k == "rewardPoolAddress" {
-			_v, err := hex.DecodeString(v.(string))
+		switch k {
+		case "maxTotalSupply", "gasPrice", "deadAddress", "rewardPoolAddress":
+			strValue, ok := v.(string)
+			if !ok {
+				return fmt.Errorf("invalid %s: expected string", k)
+			}
+
+			if k == "maxTotalSupply" || k == "gasPrice" {
+				_v, err := uint256.FromDecimal(strValue)
+				if err != nil {
+					return fmt.Errorf("invalid %s: %w", k, err)
+				}
+				tmp[k] = base64.StdEncoding.EncodeToString(_v.Bytes())
+				continue
+			}
+
+			_v, err := hex.DecodeString(strValue)
 			if err != nil {
-				return err
+				return fmt.Errorf("invalid %s: %w", k, err)
 			}
 			tmp[k] = base64.StdEncoding.EncodeToString(_v)
 		}

--- a/ctrlers/types/gov_params_test.go
+++ b/ctrlers/types/gov_params_test.go
@@ -37,3 +37,61 @@ func Test_JsonCodec(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, jz, jz2)
 }
+
+func TestGovParamsUnmarshalError(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		errField string
+	}{
+		{
+			name:     "gas price type",
+			input:    `{"gasPrice": 1}`,
+			errField: "gasPrice",
+		},
+		{
+			name:     "gas price value",
+			input:    `{"gasPrice": "not-a-number"}`,
+			errField: "gasPrice",
+		},
+		{
+			name:     "total supply type",
+			input:    `{"maxTotalSupply": 1}`,
+			errField: "maxTotalSupply",
+		},
+		{
+			name:     "total supply value",
+			input:    `{"maxTotalSupply": "not-a-number"}`,
+			errField: "maxTotalSupply",
+		},
+		{
+			name:     "dead address type",
+			input:    `{"deadAddress": 1}`,
+			errField: "deadAddress",
+		},
+		{
+			name:     "dead address value",
+			input:    `{"deadAddress": "not-hex"}`,
+			errField: "deadAddress",
+		},
+		{
+			name:     "reward address type",
+			input:    `{"rewardPoolAddress": 1}`,
+			errField: "rewardPoolAddress",
+		},
+		{
+			name:     "reward address value",
+			input:    `{"rewardPoolAddress": "not-hex"}`,
+			errField: "rewardPoolAddress",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := &GovParams{}
+			err := jsonx.Unmarshal([]byte(tt.input), params)
+			require.Error(t, err)
+			require.ErrorContains(t, err, tt.errField)
+		})
+	}
+}

--- a/ctrlers/types/gov_params_test.go
+++ b/ctrlers/types/gov_params_test.go
@@ -37,3 +37,59 @@ func Test_JsonCodec(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, jz, jz2)
 }
+
+func TestGovParamsValidateBasic(t *testing.T) {
+	require.NoError(t, DefaultGovParams().ValidateBasic())
+}
+
+func TestGovParamsValidateBasic_InvalidValues(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*GovParamsProto)
+	}{
+		{
+			name: "negative_max_validator_count",
+			mutate: func(v *GovParamsProto) {
+				v.MaxValidatorCnt = -1
+			},
+		},
+		{
+			name: "zero_inflation_cycle_blocks",
+			mutate: func(v *GovParamsProto) {
+				v.InflationCycleBlocks = 0
+			},
+		},
+		{
+			name: "negative_inflation_cycle_blocks",
+			mutate: func(v *GovParamsProto) {
+				v.InflationCycleBlocks = -1
+			},
+		},
+		{
+			name: "negative_block_gas_limit",
+			mutate: func(v *GovParamsProto) {
+				v.BlockGasLimit = -1
+			},
+		},
+		{
+			name: "tx_fee_reward_rate_over_100",
+			mutate: func(v *GovParamsProto) {
+				v.TxFeeRewardRate = 200
+			},
+		},
+		{
+			name: "slash_rate_over_100",
+			mutate: func(v *GovParamsProto) {
+				v.SlashRate = 200
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := DefaultGovParams()
+			params.SetValue(tt.mutate)
+			require.Error(t, params.ValidateBasic())
+		})
+	}
+}

--- a/ctrlers/types/gov_params_test.go
+++ b/ctrlers/types/gov_params_test.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"github.com/beatoz/beatoz-go/libs/jsonx"
+	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 	"reflect"
@@ -36,4 +37,47 @@ func Test_JsonCodec(t *testing.T) {
 	jz2, err := jsonx.MarshalIndent(govParams2, "", "  ")
 	require.NoError(t, err)
 	require.Equal(t, jz, jz2)
+}
+
+func TestValidateCurrentSupply(t *testing.T) {
+	tests := []struct {
+		name          string
+		maxSupply     uint64
+		currentSupply uint64
+		wantErr       bool
+	}{
+		{
+			name:          "max_supply_less_than_current_supply",
+			maxSupply:     99,
+			currentSupply: 100,
+			wantErr:       true,
+		},
+		{
+			name:          "max_supply_equal_to_current_supply",
+			maxSupply:     100,
+			currentSupply: 100,
+		},
+		{
+			name:          "max_supply_greater_than_current_supply",
+			maxSupply:     101,
+			currentSupply: 100,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := DefaultGovParams()
+			params.SetValue(func(v *GovParamsProto) {
+				v.XMaxTotalSupply = uint256.NewInt(tt.maxSupply).Bytes()
+			})
+
+			xerr := params.ValidateCurrentSupply(uint256.NewInt(tt.currentSupply))
+			if tt.wantErr {
+				require.Error(t, xerr)
+				require.Contains(t, xerr.Error(), "maxTotalSupply")
+				return
+			}
+			require.NoError(t, xerr)
+		})
+	}
 }

--- a/ctrlers/types/handlers.go
+++ b/ctrlers/types/handlers.go
@@ -110,6 +110,7 @@ type IVPowerHandler interface {
 type ISupplyHandler interface {
 	ITrxHandler
 	IBlockHandler
+	TotalSupply() *uint256.Int
 	RequestMint(bctx *BlockContext)
 	Burn(bctx *BlockContext, amt *uint256.Int) xerrors.XError
 }

--- a/ctrlers/types/signer.go
+++ b/ctrlers/types/signer.go
@@ -6,6 +6,7 @@ import (
 	"github.com/beatoz/beatoz-go/types"
 	"github.com/beatoz/beatoz-go/types/bytes"
 	"github.com/beatoz/beatoz-go/types/xerrors"
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/holiman/uint256"
 )
@@ -40,6 +41,9 @@ func getSigner(v byte) (ISigner, xerrors.XError) {
 }
 
 func VerifyTrxRLP(tx *Trx) (types.Address, bytes.HexBytes, xerrors.XError) {
+	if len(tx.Sig) != ethcrypto.SignatureLength {
+		return nil, nil, xerrors.ErrInvalidTrxSig.Wrapf("sig length is invalid - expected: %d, actual: %d", ethcrypto.SignatureLength, len(tx.Sig))
+	}
 	signer, xerr := getSigner(tx.Sig[64])
 	if xerr != nil {
 		return nil, nil, xerr
@@ -48,6 +52,9 @@ func VerifyTrxRLP(tx *Trx) (types.Address, bytes.HexBytes, xerrors.XError) {
 }
 
 func VerifyPayerTrxRLP(tx *Trx) (types.Address, bytes.HexBytes, xerrors.XError) {
+	if len(tx.PayerSig) != ethcrypto.SignatureLength {
+		return nil, nil, xerrors.ErrInvalidTrxSig.Wrapf("payer sig length is invalid - expected: %d, actual: %d", ethcrypto.SignatureLength, len(tx.PayerSig))
+	}
 	signer, xerr := getSigner(tx.PayerSig[64])
 	if xerr != nil {
 		return nil, nil, xerr

--- a/ctrlers/types/signer_test.go
+++ b/ctrlers/types/signer_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/beatoz/beatoz-go/types"
 	"github.com/beatoz/beatoz-go/types/bytes"
 	"github.com/beatoz/beatoz-go/types/crypto"
+	"github.com/beatoz/beatoz-go/types/xerrors"
 	"github.com/beatoz/beatoz-sdk-go/web3"
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
@@ -17,6 +18,56 @@ import (
 
 func init() {
 	ctrtypes.InitSigner(chainId)
+}
+
+func TestVerifyTrxRLPInvalidSignature(t *testing.T) {
+	tests := []struct {
+		name string
+		sig  bytes.HexBytes
+	}{
+		{name: "nil", sig: nil},
+		{name: "one_byte", sig: bytes.HexBytes{0x01}},
+		{name: "sixty_four_bytes", sig: bytes.HexBytes(bytes.ZeroBytes(64))},
+		{name: "invalid_v", sig: bytes.HexBytes(append(bytes.ZeroBytes(64), 99))},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tx := &ctrtypes.Trx{Sig: tt.sig}
+			var xerr xerrors.XError
+
+			require.NotPanics(t, func() {
+				_, _, xerr = ctrtypes.VerifyTrxRLP(tx)
+			})
+			require.Error(t, xerr)
+			require.True(t, xerr.Contains(xerrors.ErrInvalidTrxSig), "unexpected error: %v", xerr)
+		})
+	}
+}
+
+func TestVerifyPayerTrxRLPInvalidSignature(t *testing.T) {
+	tests := []struct {
+		name string
+		sig  bytes.HexBytes
+	}{
+		{name: "nil", sig: nil},
+		{name: "one_byte", sig: bytes.HexBytes{0x01}},
+		{name: "sixty_four_bytes", sig: bytes.HexBytes(bytes.ZeroBytes(64))},
+		{name: "invalid_v", sig: bytes.HexBytes(append(bytes.ZeroBytes(64), 99))},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tx := &ctrtypes.Trx{PayerSig: tt.sig}
+			var xerr xerrors.XError
+
+			require.NotPanics(t, func() {
+				_, _, xerr = ctrtypes.VerifyPayerTrxRLP(tx)
+			})
+			require.Error(t, xerr)
+			require.True(t, xerr.Contains(xerrors.ErrInvalidTrxSig), "unexpected error: %v", xerr)
+		})
+	}
 }
 
 func TestSignerV0_Recover(t *testing.T) {

--- a/ctrlers/types/trx.go
+++ b/ctrlers/types/trx.go
@@ -7,6 +7,7 @@ import (
 	"github.com/beatoz/beatoz-go/types"
 	"github.com/beatoz/beatoz-go/types/bytes"
 	"github.com/beatoz/beatoz-go/types/xerrors"
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/holiman/uint256"
 	"google.golang.org/protobuf/proto"
@@ -359,14 +360,14 @@ func (tx *Trx) Validate() xerrors.XError {
 	if tx.Payload != nil && tx.Type != tx.Payload.Type() {
 		return xerrors.ErrInvalidTrxPayloadType
 	}
-	if tx.Sig == nil {
-		return xerrors.ErrInvalidTrxSig
+	if len(tx.Sig) != ethcrypto.SignatureLength {
+		return xerrors.ErrInvalidTrxSig.Wrapf("sig length is invalid - expected: %d, actual: %d", ethcrypto.SignatureLength, len(tx.Sig))
 	}
 	if tx.Payer != nil && len(tx.Payer) != types.AddrSize {
 		return xerrors.ErrInvalidAddress.Wrapf("payer(%v)'s addr is invalid", tx.Payer)
 	}
-	if tx.Payer != nil && tx.PayerSig == nil {
-		return xerrors.ErrInvalidTrxSig.Wrapf("payer(%v)'s sig is nil", tx.Payer)
+	if tx.Payer != nil && len(tx.PayerSig) != ethcrypto.SignatureLength {
+		return xerrors.ErrInvalidTrxSig.Wrapf("payer(%v)'s sig length is invalid - expected: %d, actual: %d", tx.Payer, ethcrypto.SignatureLength, len(tx.PayerSig))
 	}
 	return nil
 }

--- a/ctrlers/types/trx_test.go
+++ b/ctrlers/types/trx_test.go
@@ -44,6 +44,48 @@ func TestTrxEncode(t *testing.T) {
 	require.Equal(t, bzTx0, bzTx1)
 }
 
+func TestTrxValidateInvalidSignature(t *testing.T) {
+	validSig := bytes.HexBytes(bytes.ZeroBytes(65))
+	tests := []struct {
+		name     string
+		sig      bytes.HexBytes
+		payer    types.Address
+		payerSig bytes.HexBytes
+	}{
+		{name: "nil_sender_sig", sig: nil},
+		{name: "one_byte_sender_sig", sig: bytes.HexBytes{0x01}},
+		{name: "sixty_four_byte_sender_sig", sig: bytes.HexBytes(bytes.ZeroBytes(64))},
+		{name: "sixty_six_byte_sender_sig", sig: bytes.HexBytes(bytes.ZeroBytes(66))},
+		{name: "nil_payer_sig", sig: validSig, payer: types.RandAddress(), payerSig: nil},
+		{name: "one_byte_payer_sig", sig: validSig, payer: types.RandAddress(), payerSig: bytes.HexBytes{0x01}},
+		{name: "sixty_four_byte_payer_sig", sig: validSig, payer: types.RandAddress(), payerSig: bytes.HexBytes(bytes.ZeroBytes(64))},
+		{name: "sixty_six_byte_payer_sig", sig: validSig, payer: types.RandAddress(), payerSig: bytes.HexBytes(bytes.ZeroBytes(66))},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tx := &types2.Trx{
+				Version:  1,
+				Time:     time.Now().UnixNano(),
+				Nonce:    rand.Int63(),
+				From:     types.RandAddress(),
+				To:       types.RandAddress(),
+				Amount:   uint256.NewInt(0),
+				Gas:      rand.Int63(),
+				GasPrice: uint256.NewInt(rand.Uint64()),
+				Type:     types2.TRX_TRANSFER,
+				Sig:      tt.sig,
+				Payer:    tt.payer,
+				PayerSig: tt.payerSig,
+			}
+
+			xerr := tx.Validate()
+			require.Error(t, xerr)
+			require.True(t, xerr.Contains(xerrors.ErrInvalidTrxSig), "unexpected error: %v", xerr)
+		})
+	}
+}
+
 func TestTrxDecodeWithMaliciousPayload(t *testing.T) {
 	// The malicious users can exploit this by submitting a large number of TRX_TRANSFER and TRX_STAKING transactions,
 	// each with a large payload but under 1MB in size.

--- a/node/app.go
+++ b/node/app.go
@@ -490,6 +490,7 @@ func (ctrler *BeatozApp) DeliverTx(req abcitypes.RequestDeliverTx) abcitypes.Res
 	// Parallel tx processing.
 	// Just request to create `TrxContext` with `req RequestDeliverTx`.
 	// The executions for this `req RequestDeliverTx` will be done in `EncBlockSync`
+	ctrler.currBlockCtx.AddTxsCnt(1)
 	ctrler.txExecutor.Add(
 		&req,
 		func(req *abcitypes.RequestDeliverTx, idx int) (*ctrlertypes.TrxContext, *abcitypes.ResponseDeliverTx) {
@@ -506,7 +507,7 @@ func (ctrler *BeatozApp) DeliverTx(req abcitypes.RequestDeliverTx) abcitypes.Res
 				}
 			}
 
-			ctrler.currBlockCtx.AddTxsCnt(1)
+			txctx.TxIdx = idx
 			return txctx, nil
 		},
 	)
@@ -629,8 +630,9 @@ func (ctrler *BeatozApp) EndBlock(req abcitypes.RequestEndBlock) abcitypes.Respo
 		ctrler.txExecutor.TrxPreparer.Wait()
 		// for debugging
 		if ctrler.txExecutor.TrxPreparer.resultCount() != ctrler.currBlockCtx.TxsCnt() {
-			panic(fmt.Sprintf("error: len(client.deliverTxReqs)(%v) != txs count in block(%v)",
-				ctrler.txExecutor.TrxPreparer.resultCount(), ctrler.currBlockCtx.TxsCnt()))
+			ctrler.logger.Error("transaction count mismatch",
+				"prepared", ctrler.txExecutor.TrxPreparer.resultCount(),
+				"blockTxs", ctrler.currBlockCtx.TxsCnt())
 		}
 
 		// Execute every transaction in its own `TrxContext` sequentially

--- a/node/app_test.go
+++ b/node/app_test.go
@@ -20,6 +20,61 @@ import (
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 )
 
+func newTestBeatozApp(t *testing.T, wallets []*web3.Wallet) (*BeatozApp, *beatozLocalClient, func()) {
+	t.Helper()
+
+	appState := genesis.GenesisAppState{
+		AssetHolders: make([]*genesis.GenesisAssetHolder, len(wallets)),
+		GovParams:    types.DefaultGovParams(),
+	}
+	for i, w := range wallets {
+		appState.AssetHolders[i] = &genesis.GenesisAssetHolder{
+			Address: w.Address(),
+			Balance: types2.ToGrans(1_000),
+		}
+	}
+	jz, err := jsonx.Marshal(appState)
+	require.NoError(t, err)
+
+	btxcfg := config.DefaultConfig("1234")
+	btxcfg.SetRoot(filepath.Join(t.TempDir(), "beatoz-test"))
+
+	btzApp := NewBeatozApp(btxcfg, log.NewNopLogger())
+	btzClient := NewBeatozLocalClient(&tmsync.Mutex{}, btzApp)
+	btzClient.SetResponseCallback(func(*abcitypes.Request, *abcitypes.Response) {})
+	btzApp.SetLocalClient(btzClient)
+
+	btzApp.Info(abcitypes.RequestInfo{})
+	btzApp.InitChain(abcitypes.RequestInitChain{
+		ChainId: btxcfg.ChainIdHex(),
+		ConsensusParams: &abcitypes.ConsensusParams{
+			Block: &abcitypes.BlockParams{
+				MaxBytes: 22020096,
+				MaxGas:   36_000_000,
+			},
+		},
+		Validators: abcitypes.ValidatorUpdates{
+			abcitypes.UpdateValidator(wallets[0].GetPubKey(), 1_000_000, "secp256k1"),
+		},
+		AppStateBytes: jz,
+		InitialHeight: 1,
+	})
+	btzApp.Start()
+
+	btzApp.BeginBlock(abcitypes.RequestBeginBlock{
+		Header: tmproto.Header{Height: 1, ChainID: btxcfg.ChainIdHex()},
+	})
+	btzApp.EndBlock(abcitypes.RequestEndBlock{Height: 1})
+	btzApp.Commit()
+
+	cleanup := func() {
+		btzApp.Stop()
+		os.RemoveAll(btxcfg.RootDir)
+		types.InitSigner(chainId)
+	}
+	return btzApp, btzClient.(*beatozLocalClient), cleanup
+}
+
 func Test_InitChain(t *testing.T) {
 	// max total supply is less than initial total supply
 	req := abcitypes.RequestInitChain{
@@ -58,6 +113,112 @@ func Test_InitChain(t *testing.T) {
 	_, genTotalSupply, err := checkRequestInitChain(req)
 	require.NoError(t, err)
 	require.Equal(t, "6000000000000000000", genTotalSupply.Dec())
+}
+
+func Test_EndBlock_NoChainHalt(t *testing.T) {
+	testCases := []struct {
+		name  string
+		build func(t *testing.T, app *BeatozApp, chainID string, wallets []*web3.Wallet) []byte
+	}{
+		{
+			name: "wrong_gas_price",
+			build: func(t *testing.T, app *BeatozApp, chainID string, wallets []*web3.Wallet) []byte {
+				gasPrice := new(uint256.Int).Add(app.govCtrler.GasPrice(), uint256.NewInt(1))
+				tx := web3.NewTrxTransfer(
+					wallets[0].Address(), types2.RandAddress(),
+					wallets[0].GetNonce(),
+					app.govCtrler.MinTrxGas(), gasPrice,
+					uint256.NewInt(1),
+				)
+				_, _, err := wallets[0].SignTrxRLP(tx, chainID)
+				require.NoError(t, err)
+				txbz, err := tx.Encode()
+				require.NoError(t, err)
+				return txbz
+			},
+		},
+		{
+			name: "small_gas",
+			build: func(t *testing.T, app *BeatozApp, chainID string, wallets []*web3.Wallet) []byte {
+				tx := web3.NewTrxTransfer(
+					wallets[0].Address(), types2.RandAddress(),
+					wallets[0].GetNonce(),
+					app.govCtrler.MinTrxGas()-1, app.govCtrler.GasPrice(),
+					uint256.NewInt(1),
+				)
+				_, _, err := wallets[0].SignTrxRLP(tx, chainID)
+				require.NoError(t, err)
+				txbz, err := tx.Encode()
+				require.NoError(t, err)
+				return txbz
+			},
+		},
+		{
+			name: "wrong_signature",
+			build: func(t *testing.T, app *BeatozApp, chainID string, wallets []*web3.Wallet) []byte {
+				tx := web3.NewTrxTransfer(
+					wallets[0].Address(), types2.RandAddress(),
+					wallets[0].GetNonce(),
+					app.govCtrler.MinTrxGas(), app.govCtrler.GasPrice(),
+					uint256.NewInt(1),
+				)
+				_, _, err := wallets[1].SignTrxRLP(tx, chainID)
+				require.NoError(t, err)
+				txbz, err := tx.Encode()
+				require.NoError(t, err)
+				return txbz
+			},
+		},
+		{
+			name: "sender_not_found",
+			build: func(t *testing.T, app *BeatozApp, chainID string, wallets []*web3.Wallet) []byte {
+				unknownSender := web3.NewWallet(nil)
+				tx := web3.NewTrxTransfer(
+					unknownSender.Address(), types2.RandAddress(),
+					unknownSender.GetNonce(),
+					app.govCtrler.MinTrxGas(), app.govCtrler.GasPrice(),
+					uint256.NewInt(1),
+				)
+				_, _, err := unknownSender.SignTrxRLP(tx, chainID)
+				require.NoError(t, err)
+				txbz, err := tx.Encode()
+				require.NoError(t, err)
+				return txbz
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			wallets := []*web3.Wallet{web3.NewWallet(nil), web3.NewWallet(nil)}
+			btzApp, btzClient, cleanup := newTestBeatozApp(t, wallets)
+			defer cleanup()
+
+			var deliverTxResp *abcitypes.ResponseDeliverTx
+			btzClient.SetResponseCallback(func(req *abcitypes.Request, resp *abcitypes.Response) {
+				if r := resp.GetDeliverTx(); r != nil {
+					deliverTxResp = r
+				}
+			})
+
+			chainID := btzApp.lastBlockCtx.ChainID()
+			txbz := tc.build(t, btzApp, chainID, wallets)
+
+			btzApp.BeginBlock(abcitypes.RequestBeginBlock{
+				Header: tmproto.Header{Height: 2, ChainID: chainID},
+			})
+			btzApp.DeliverTx(abcitypes.RequestDeliverTx{Tx: txbz})
+			require.Equal(t, 1, btzApp.currBlockCtx.TxsCnt())
+
+			require.NotPanics(t, func() {
+				btzApp.EndBlock(abcitypes.RequestEndBlock{Height: 2})
+			})
+			require.NotNil(t, deliverTxResp)
+			require.NotEqual(t, abcitypes.CodeTypeOK, deliverTxResp.Code)
+
+			btzApp.Commit()
+		})
+	}
 }
 
 func Benchmark_TxLifeCycle(b *testing.B) {

--- a/test/81_governance_test.go
+++ b/test/81_governance_test.go
@@ -50,7 +50,7 @@ func TestIncorrectProposal(t *testing.T) {
 	newGovParams := &types.GovParams{}
 	newGovParams.SetValue(func(v *types.GovParamsProto) {
 		v.Version = rand.Int32()
-		v.SlashRate = rand.Int32()
+		v.SlashRate = int32(rand.Intn(101))
 		v.XRewardPoolAddress = bytes.RandBytes(20)
 	})
 	bzOpt, err = jsonx.Marshal(newGovParams)
@@ -108,7 +108,7 @@ func TestProposalAndVoting(t *testing.T) {
 	newGovParams := &types.GovParams{}
 	newGovParams.SetValue(func(v *types.GovParamsProto) {
 		v.Version = rand.Int32()
-		v.SlashRate = rand.Int32()
+		v.SlashRate = int32(rand.Intn(101))
 		v.XRewardPoolAddress = bytes.RandBytes(20)
 	})
 	bzOpt, err := jsonx.Marshal(newGovParams)


### PR DESCRIPTION
# Harden Transaction, Governance Parameter, and Supply Validation

## Summary

This PR merges the fixes from `fix/bg-590`, `fix/bg-593`, `fix/bg-594`, `fix/bg-599`, and `fix/bg-600` into `fix/pr65-72` for the develop branch PR.

It prevents several panic and consensus-risk paths around invalid transactions, malformed governance parameter payloads, invalid governance parameter proposals, and supply-limit handling.

Previously, invalid transaction contexts, short signatures, malformed governance parameter JSON, semantically invalid governance parameters, or a `maxTotalSupply` below the current supply could reach code paths that either panicked or produced unsafe state-transition behavior.

The specific issue addressed by this PR is tracked in 

- [BG-590](https://beatoz.atlassian.net/jira/software/projects/BG/boards/82?selectedIssue=BG-590), 
- [BG-593](https://beatoz.atlassian.net/jira/software/projects/BG/boards/82?selectedIssue=BG-593)
- [BG-594](https://beatoz.atlassian.net/jira/software/projects/BG/boards/82?selectedIssue=BG-594)
- [BG-599](https://beatoz.atlassian.net/jira/software/projects/BG/boards/82?selectedIssue=BG-599)
- [BG-600](https://beatoz.atlassian.net/jira/software/projects/BG/boards/82?selectedIssue=BG-600)

## Changes

- Prevent `EndBlock` from panicking when invalid transactions fail during `NewTrxContext` creation.
- Validate sender and payer signature lengths before transaction verification reads recovery id bytes.
- Add semantic validation for governance parameters and enforce it during proposal validation and frozen proposal application.
- Convert malformed governance parameter JSON handling from panic paths into returned errors.
- Reject governance parameter proposals whose `maxTotalSupply` is below the current total supply.
- Add `TotalSupply()` to the supply handler contract and implement it for real and mock supply controllers.
- Prevent additional supply calculation from underflowing when the configured max supply has already been reached or exceeded.
- Add regression tests for invalid transaction handling, signature validation, governance parameter validation, JSON unmarshal errors, and supply-limit boundaries.

## Changed Files

- `node/app.go`: updates delivered transaction count handling and removes the tx count mismatch panic path.
- `node/app_test.go`: adds regression coverage for invalid transactions that fail context creation.
- `ctrlers/types/trx.go`: rejects transactions with invalid sender or payer signature lengths.
- `ctrlers/types/trx_test.go`: adds validation coverage for malformed sender and payer signatures.
- `ctrlers/types/signer.go`: adds defensive signature length checks before RLP signature verification indexes signature bytes.
- `ctrlers/types/signer_test.go`: adds no-panic regression coverage for invalid signature verification.
- `ctrlers/types/gov_params.go`: adds governance parameter validation, current supply validation, and safe JSON special-field decoding.
- `ctrlers/types/gov_params_test.go`: adds validation, unmarshal error, and current supply boundary coverage.
- `ctrlers/types/handlers.go`: adds `TotalSupply()` to `ISupplyHandler`.
- `ctrlers/gov/ctrler.go`: validates merged governance parameter proposal options and checks `maxTotalSupply` against current supply.
- `ctrlers/gov/ctrler_block.go`: reports rejected invalid frozen proposals in block events.
- `ctrlers/gov/1_proposal_test.go`: adds invalid governance parameter proposal and invalid max supply coverage.
- `ctrlers/gov/2_voting_test.go`: adds regression coverage for rejecting invalid frozen governance parameter proposals.
- `ctrlers/gov/helpers_test.go`: provides a supply handler stub for governance tests.
- `ctrlers/gov/ctrler_punish_test.go`: supplies the required supply handler dependency in block process tests.
- `ctrlers/supply/ctrler.go`: implements a read-locked total supply getter.
- `ctrlers/supply/ctrler_mint.go`: returns zero additional supply when the supply limit is reached or exceeded.
- `ctrlers/supply/ctrler_mint_test.go`: adds supply limit boundary regression coverage.
- `ctrlers/mocks/supply/ctrler_mock.go`: implements the new supply handler method.
- `test/81_governance_test.go`: constrains randomized slash rate test values to the valid percent range.

## Test

```bash
go test ./...
```

Result:

```text
ok  	github.com/beatoz/beatoz-go/cmd/commands	3.290s
ok  	github.com/beatoz/beatoz-go/cmd/version	2.865s
ok  	github.com/beatoz/beatoz-go/ctrlers	7.116s
ok  	github.com/beatoz/beatoz-go/ctrlers/account	23.256s
ok  	github.com/beatoz/beatoz-go/ctrlers/gov	(cached)
ok  	github.com/beatoz/beatoz-go/ctrlers/gov/proposal	3.692s
ok  	github.com/beatoz/beatoz-go/ctrlers/supply	6.558s
ok  	github.com/beatoz/beatoz-go/ctrlers/types	(cached)
ok  	github.com/beatoz/beatoz-go/ctrlers/vm/evm	1.796s
ok  	github.com/beatoz/beatoz-go/ctrlers/vpower	23.330s
ok  	github.com/beatoz/beatoz-go/ledger	0.942s
ok  	github.com/beatoz/beatoz-go/ledger/v0	1.243s
ok  	github.com/beatoz/beatoz-go/ledger/v1	3.511s
ok  	github.com/beatoz/beatoz-go/libs/fxnum	5.004s
ok  	github.com/beatoz/beatoz-go/libs/jsonx	5.318s
ok  	github.com/beatoz/beatoz-go/node	10.615s
ok  	github.com/beatoz/beatoz-go/test	196.847s
ok  	github.com/beatoz/beatoz-go/types	5.967s
ok  	github.com/beatoz/beatoz-go/types/bytes	5.751s
ok  	github.com/beatoz/beatoz-go/types/crypto	5.282s
ok  	github.com/beatoz/beatoz-go/types/merkle	4.938s
ok  	github.com/beatoz/beatoz-go/types/xerrors	5.252s
```
