### PR TITLE
Non-EVM Transaction Rollback

### DIFF
--- a/ctrlers/account/ctrler.go
+++ b/ctrlers/account/ctrler.go
@@ -307,6 +307,20 @@ func (ctrler *AcctCtrler) SetAccount(acct *btztypes.Account, exec bool) xerrors.
 	return ctrler.setAccount(acct, exec)
 }
 
+func (ctrler *AcctCtrler) Snapshot(exec bool) v1.Snapshot {
+	ctrler.mtx.RLock()
+	defer ctrler.mtx.RUnlock()
+
+	return ctrler.acctState.Snapshot(exec)
+}
+
+func (ctrler *AcctCtrler) RevertToSnapshot(snap v1.Snapshot, exec bool) xerrors.XError {
+	ctrler.mtx.RLock()
+	defer ctrler.mtx.RUnlock()
+
+	return ctrler.acctState.RevertToSnapshot(snap, exec)
+}
+
 func (ctrler *AcctCtrler) setAccount(acct *btztypes.Account, exec bool) xerrors.XError {
 	return ctrler.acctState.Set(v1.LedgerKeyAccount(acct.Address), acct, exec)
 }
@@ -328,6 +342,7 @@ var _ btztypes.ILedgerHandler = (*AcctCtrler)(nil)
 var _ btztypes.ITrxHandler = (*AcctCtrler)(nil)
 var _ btztypes.IBlockHandler = (*AcctCtrler)(nil)
 var _ btztypes.IAccountHandler = (*AcctCtrler)(nil)
+var _ btztypes.ITrxLedgerSnapshotter = (*AcctCtrler)(nil)
 
 type SimuAcctCtrler struct {
 	simuLedger v1.IImitable

--- a/ctrlers/gov/ctrler.go
+++ b/ctrlers/gov/ctrler.go
@@ -379,6 +379,20 @@ func (ctrler *GovCtrler) Close() xerrors.XError {
 	return nil
 }
 
+func (ctrler *GovCtrler) Snapshot(exec bool) v1.Snapshot {
+	ctrler.mtx.RLock()
+	defer ctrler.mtx.RUnlock()
+
+	return ctrler.govState.Snapshot(exec)
+}
+
+func (ctrler *GovCtrler) RevertToSnapshot(snap v1.Snapshot, exec bool) xerrors.XError {
+	ctrler.mtx.RLock()
+	defer ctrler.mtx.RUnlock()
+
+	return ctrler.govState.RevertToSnapshot(snap, exec)
+}
+
 func (ctrler *GovCtrler) ReadAllProposals(exec bool) ([]*proposal.GovProposal, xerrors.XError) {
 	ctrler.mtx.RLock()
 	defer ctrler.mtx.RUnlock()
@@ -418,3 +432,4 @@ var _ ctrlertypes.ILedgerHandler = (*GovCtrler)(nil)
 var _ ctrlertypes.ITrxHandler = (*GovCtrler)(nil)
 var _ ctrlertypes.IBlockHandler = (*GovCtrler)(nil)
 var _ ctrlertypes.IGovParams = (*GovCtrler)(nil)
+var _ ctrlertypes.ITrxLedgerSnapshotter = (*GovCtrler)(nil)

--- a/ctrlers/mocks/acct/ctrler_mock.go
+++ b/ctrlers/mocks/acct/ctrler_mock.go
@@ -152,7 +152,7 @@ func (mock *AcctHandlerMock) SetBalance(addr types.Address, amt *uint256.Int, ex
 func (mock *AcctHandlerMock) SimuAcctCtrlerAt(i int64) (ctrlertypes.IAccountHandler, xerrors.XError) {
 	return &AcctHandlerMock{}, nil
 }
-func (mock *AcctHandlerMock) SetAccount(acct *ctrlertypes.Account, b bool) xerrors.XError {
+func (mock *AcctHandlerMock) SetAccount(acct *ctrlertypes.Account, _ bool) xerrors.XError {
 	if w := mock.FindWallet(acct.Address); w != nil {
 		copyAccount(w.GetAccount(), acct)
 		return nil

--- a/ctrlers/mocks/acct/ctrler_mock.go
+++ b/ctrlers/mocks/acct/ctrler_mock.go
@@ -2,6 +2,7 @@ package acct
 
 import (
 	ctrlertypes "github.com/beatoz/beatoz-go/ctrlers/types"
+	v1 "github.com/beatoz/beatoz-go/ledger/v1"
 	"github.com/beatoz/beatoz-go/types"
 	"github.com/beatoz/beatoz-go/types/xerrors"
 	"github.com/beatoz/beatoz-sdk-go/web3"
@@ -11,8 +12,16 @@ import (
 )
 
 type AcctHandlerMock struct {
+	wallets     []*web3.Wallet
+	accounts    []*ctrlertypes.Account // has no private key
+	snapshots   []acctHandlerSnapshot
+	snapshotCnt int
+	revertCnt   int
+}
+
+type acctHandlerSnapshot struct {
 	wallets  []*web3.Wallet
-	accounts []*ctrlertypes.Account // has no private key
+	accounts []*ctrlertypes.Account
 }
 
 func NewAcctHandlerMock(walCnt int) *AcctHandlerMock {
@@ -144,7 +153,57 @@ func (mock *AcctHandlerMock) SimuAcctCtrlerAt(i int64) (ctrlertypes.IAccountHand
 	return &AcctHandlerMock{}, nil
 }
 func (mock *AcctHandlerMock) SetAccount(acct *ctrlertypes.Account, b bool) xerrors.XError {
+	if w := mock.FindWallet(acct.Address); w != nil {
+		copyAccount(w.GetAccount(), acct)
+		return nil
+	}
+	for i, old := range mock.accounts {
+		if acct.Address.Compare(old.Address) == 0 {
+			mock.accounts[i] = acct.Clone()
+			return nil
+		}
+	}
+	mock.accounts = append(mock.accounts, acct.Clone())
 	return nil
+}
+
+func (mock *AcctHandlerMock) Snapshot(bool) v1.Snapshot {
+	mock.snapshotCnt++
+	mock.snapshots = append(mock.snapshots, acctHandlerSnapshot{
+		wallets:  cloneWallets(mock.wallets),
+		accounts: cloneAccounts(mock.accounts),
+	})
+	return v1.Snapshot{}
+}
+
+func (mock *AcctHandlerMock) RevertToSnapshot(v1.Snapshot, bool) xerrors.XError {
+	if len(mock.snapshots) == 0 {
+		return xerrors.ErrInvalidSnapshot
+	}
+	mock.revertCnt++
+	snap := mock.snapshots[len(mock.snapshots)-1]
+	mock.snapshots = mock.snapshots[:len(mock.snapshots)-1]
+
+	if len(mock.wallets) > len(snap.wallets) {
+		mock.wallets = mock.wallets[:len(snap.wallets)]
+	}
+	for i, snapWallet := range snap.wallets {
+		if i < len(mock.wallets) {
+			copyAccount(mock.wallets[i].GetAccount(), snapWallet.GetAccount())
+		} else {
+			mock.wallets = append(mock.wallets, snapWallet.Clone())
+		}
+	}
+	mock.accounts = cloneAccounts(snap.accounts)
+	return nil
+}
+
+func (mock *AcctHandlerMock) SnapshotCount() int {
+	return mock.snapshotCnt
+}
+
+func (mock *AcctHandlerMock) RevertCount() int {
+	return mock.revertCnt
 }
 
 func (mock *AcctHandlerMock) BeginBlock(bctx *ctrlertypes.BlockContext) ([]abcitypes.Event, xerrors.XError) {
@@ -176,4 +235,29 @@ func (mock *AcctHandlerMock) ExecuteTrx(ctx *ctrlertypes.TrxContext) xerrors.XEr
 	return nil
 }
 
+func cloneWallets(src []*web3.Wallet) []*web3.Wallet {
+	ret := make([]*web3.Wallet, len(src))
+	for i, w := range src {
+		ret[i] = w.Clone()
+	}
+	return ret
+}
+
+func cloneAccounts(src []*ctrlertypes.Account) []*ctrlertypes.Account {
+	ret := make([]*ctrlertypes.Account, len(src))
+	for i, acct := range src {
+		ret[i] = acct.Clone()
+	}
+	return ret
+}
+
+func copyAccount(dst, src *ctrlertypes.Account) {
+	dst.SetName(src.GetName())
+	dst.SetDocURL(src.GetDocURL())
+	dst.SetNonce(src.GetNonce())
+	dst.SetBalance(src.GetBalance())
+	dst.SetCode(src.GetCode())
+}
+
 var _ ctrlertypes.IAccountHandler = (*AcctHandlerMock)(nil)
+var _ ctrlertypes.ITrxLedgerSnapshotter = (*AcctHandlerMock)(nil)

--- a/ctrlers/supply/ctrler.go
+++ b/ctrlers/supply/ctrler.go
@@ -149,7 +149,22 @@ func (ctrler *SupplyCtrler) Close() xerrors.XError {
 	return nil
 }
 
+func (ctrler *SupplyCtrler) Snapshot(exec bool) v1.Snapshot {
+	ctrler.mtx.RLock()
+	defer ctrler.mtx.RUnlock()
+
+	return ctrler.supplyState.Snapshot(exec)
+}
+
+func (ctrler *SupplyCtrler) RevertToSnapshot(snap v1.Snapshot, exec bool) xerrors.XError {
+	ctrler.mtx.RLock()
+	defer ctrler.mtx.RUnlock()
+
+	return ctrler.supplyState.RevertToSnapshot(snap, exec)
+}
+
 var _ ctrlertypes.ISupplyHandler = (*SupplyCtrler)(nil)
 var _ ctrlertypes.ITrxHandler = (*SupplyCtrler)(nil)
 var _ ctrlertypes.IBlockHandler = (*SupplyCtrler)(nil)
 var _ ctrlertypes.ILedgerHandler = (*SupplyCtrler)(nil)
+var _ ctrlertypes.ITrxLedgerSnapshotter = (*SupplyCtrler)(nil)

--- a/ctrlers/types/handlers.go
+++ b/ctrlers/types/handlers.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	v1 "github.com/beatoz/beatoz-go/ledger/v1"
 	"github.com/beatoz/beatoz-go/types"
 	"github.com/beatoz/beatoz-go/types/xerrors"
 	"github.com/holiman/uint256"
@@ -25,6 +26,11 @@ type IBlockHandler interface {
 type ITrxHandler interface {
 	ValidateTrx(*TrxContext) xerrors.XError
 	ExecuteTrx(*TrxContext) xerrors.XError
+}
+
+type ITrxLedgerSnapshotter interface {
+	Snapshot(exec bool) v1.Snapshot
+	RevertToSnapshot(snap v1.Snapshot, exec bool) xerrors.XError
 }
 
 type IGovParams interface {

--- a/ctrlers/vpower/ctrler.go
+++ b/ctrlers/vpower/ctrler.go
@@ -487,7 +487,22 @@ func (ctrler *VPowerCtrler) ImitableState(h int64) (v1.IImitable, xerrors.XError
 	return ctrler.vpowerState.ImitableLedgerAt(h)
 }
 
+func (ctrler *VPowerCtrler) Snapshot(exec bool) v1.Snapshot {
+	ctrler.mtx.RLock()
+	defer ctrler.mtx.RUnlock()
+
+	return ctrler.vpowerState.Snapshot(exec)
+}
+
+func (ctrler *VPowerCtrler) RevertToSnapshot(snap v1.Snapshot, exec bool) xerrors.XError {
+	ctrler.mtx.RLock()
+	defer ctrler.mtx.RUnlock()
+
+	return ctrler.vpowerState.RevertToSnapshot(snap, exec)
+}
+
 var _ ctrlertypes.ILedgerHandler = (*VPowerCtrler)(nil)
 var _ ctrlertypes.ITrxHandler = (*VPowerCtrler)(nil)
 var _ ctrlertypes.IBlockHandler = (*VPowerCtrler)(nil)
 var _ ctrlertypes.IVPowerHandler = (*VPowerCtrler)(nil)
+var _ ctrlertypes.ITrxLedgerSnapshotter = (*VPowerCtrler)(nil)

--- a/ledger/v1/mem_ledger.go
+++ b/ledger/v1/mem_ledger.go
@@ -188,27 +188,39 @@ func (ledger *MemLedger) Del(key LedgerKey) xerrors.XError {
 	defer ledger.mtx.Unlock()
 
 	keystr := unsafe.String(&key[0], len(key))
-	if oldVal, ok := ledger.memStorage[keystr]; ok {
-		ledger.revisions.set(key, oldVal)
+	oldVal, ok := ledger.memStorage[keystr]
+	if !ok && ledger.immuTree != nil {
+		var err error
+		oldVal, err = ledger.immuTree.Get(key)
+		if err != nil {
+			return xerrors.From(err)
+		}
+	}
+	if oldVal == nil {
+		return nil
 	}
 
+	ledger.revisions.set(key, oldVal)
 	ledger.memStorage[keystr] = nil // delete from memory. don't read from immuTree.
-
 	return nil
 }
 
-func (ledger *MemLedger) Snapshot() int {
+func (ledger *MemLedger) Snapshot() Snapshot {
 	ledger.mtx.RLock()
 	defer ledger.mtx.RUnlock()
 
 	return ledger.revisions.snapshot()
 }
 
-func (ledger *MemLedger) RevertToSnapshot(snap int) xerrors.XError {
+func (ledger *MemLedger) RevertToSnapshot(snap Snapshot) xerrors.XError {
 	ledger.mtx.Lock()
 	defer ledger.mtx.Unlock()
 
-	restores := ledger.revisions.revs[snap:]
+	if xerr := ledger.revisions.validateSnapshot(snap); xerr != nil {
+		return xerr
+	}
+
+	restores := ledger.revisions.revs[snap.revision:]
 	for i := len(restores) - 1; i >= 0; i-- {
 		kv := restores[i]
 		keystr := unsafe.String(&kv.key[0], len(kv.key))

--- a/ledger/v1/mem_ledger_test.go
+++ b/ledger/v1/mem_ledger_test.go
@@ -131,12 +131,16 @@ func TestMemLedger_RevertToSnapshot_Set1(t *testing.T) {
 	for i := 0; i < 10000; i++ {
 		oriItems = append(oriItems, newItem(i, fmt.Sprintf("d%d", i)))
 	}
-	for _, it := range oriItems {
+	var firstSnap Snapshot
+	for i, it := range oriItems {
 		require.NoError(t, ledger.Set(it.Key(), it))
+		if i == 0 {
+			firstSnap = ledger.Snapshot()
+		}
 	}
 
 	snap := ledger.Snapshot()
-	require.Equal(t, 10000, snap)
+	require.Equal(t, 10000, snap.revision)
 
 	var newItems []*Item
 	for i := 0; i < 10000; i++ {
@@ -164,7 +168,7 @@ func TestMemLedger_RevertToSnapshot_Set1(t *testing.T) {
 		require.Equal(t, fmt.Sprintf("d%d", i), item.(*Item).data)
 	}
 
-	require.NoError(t, ledger.RevertToSnapshot(1))
+	require.NoError(t, ledger.RevertToSnapshot(firstSnap))
 	k := make([]byte, 4)
 	binary.BigEndian.PutUint32(k, uint32(0))
 	item, xerr := ledger.Get(k)
@@ -185,18 +189,21 @@ func TestMemLedger_RevertToSnapshot_Set2(t *testing.T) {
 	require.NoError(t, xerr)
 
 	staticKey := 123
+	snapshots := make([]Snapshot, 10001)
+	snapshots[0] = ledger.Snapshot()
 	for i := 0; i < 10000; i++ {
 		// key 고정
 		item := newItem(staticKey, strconv.Itoa(i))
 		xerr := ledger.Set(item.Key(), item)
 		require.NoError(t, xerr)
+		snapshots[i+1] = ledger.Snapshot()
 	}
 
-	require.Equal(t, 10000, ledger.Snapshot())
+	require.Equal(t, 10000, ledger.Snapshot().revision)
 
 	for i := 10000; i >= 0; i-- {
 		// partially revert
-		require.NoError(t, ledger.RevertToSnapshot(i))
+		require.NoError(t, ledger.RevertToSnapshot(snapshots[i]))
 
 		k := make([]byte, 4)
 		binary.BigEndian.PutUint32(k, uint32(staticKey))
@@ -225,7 +232,7 @@ func TestMemLedger_RevertToSnapshot_Set_Updated(t *testing.T) {
 	require.NoError(t, xerr)
 
 	snap := ledger.Snapshot()
-	require.Equal(t, 1, snap)
+	require.Equal(t, 1, snap.revision)
 
 	_item0, xerr := ledger.Get(item.Key())
 	require.NoError(t, xerr)
@@ -259,7 +266,7 @@ func TestMemLedger_RevertToSnapshot_Del(t *testing.T) {
 
 	// get snapshot
 	snap := ledger.Snapshot()
-	require.Equal(t, 1, snap)
+	require.Equal(t, 1, snap.revision)
 
 	// delete item
 	require.NoError(t, ledger.Del(item.Key()))
@@ -272,4 +279,165 @@ func TestMemLedger_RevertToSnapshot_Del(t *testing.T) {
 	require.NoError(t, xerr)
 	require.Equal(t, item.Key(), _item.(*Item).Key())
 	require.Equal(t, item.data, _item.(*Item).data)
+}
+
+func TestMemLedger_DelPreItem(t *testing.T) {
+	ledger, xerr := NewMemLedgerAt(1, sourceLedger, log.NewNopLogger())
+	require.NoError(t, xerr)
+
+	snap := ledger.Snapshot()
+	require.NoError(t, ledger.Del(preExistedItem.Key()))
+	require.Equal(t, snap.revision+1, ledger.Snapshot().revision)
+
+	_, xerr = ledger.Get(preExistedItem.Key())
+	require.Error(t, xerr)
+	require.True(t, xerr.Contains(xerrors.ErrNotFoundResult))
+
+	require.NoError(t, ledger.RevertToSnapshot(snap))
+	restored, xerr := ledger.Get(preExistedItem.Key())
+	require.NoError(t, xerr)
+	require.Equal(t, preExistedItem.data, restored.(*Item).data)
+}
+
+func TestMemLedger_DelNoDupRev(t *testing.T) {
+	ledger, xerr := NewMemLedgerAt(1, sourceLedger, log.NewNopLogger())
+	require.NoError(t, xerr)
+
+	require.NoError(t, ledger.Del(preExistedItem.Key()))
+	afterFirstDelete := ledger.Snapshot()
+	require.NoError(t, ledger.Del(preExistedItem.Key()))
+	require.Equal(t, afterFirstDelete, ledger.Snapshot())
+
+	missingKey := newItem(987654, "").Key()
+	beforeMissingDelete := ledger.Snapshot()
+	require.NoError(t, ledger.Del(missingKey))
+	require.Equal(t, beforeMissingDelete, ledger.Snapshot())
+}
+
+func TestMemLedger_InvalidSnapshot(t *testing.T) {
+	ledger, xerr := NewMemLedgerAt(1, sourceLedger, log.NewNopLogger())
+	require.NoError(t, xerr)
+
+	t.Run("zero", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			xerr := ledger.RevertToSnapshot(Snapshot{})
+			require.Error(t, xerr)
+			require.True(t, xerr.Contains(xerrors.ErrInvalidSnapshot))
+		})
+	})
+
+	t.Run("foreign", func(t *testing.T) {
+		otherLedger, xerr := NewMemLedgerAt(1, sourceLedger, log.NewNopLogger())
+		require.NoError(t, xerr)
+
+		require.NotPanics(t, func() {
+			xerr = ledger.RevertToSnapshot(otherLedger.Snapshot())
+			require.Error(t, xerr)
+			require.True(t, xerr.Contains(xerrors.ErrInvalidSnapshot))
+		})
+	})
+
+	t.Run("generation", func(t *testing.T) {
+		snap := ledger.Snapshot()
+		snap.generation++
+
+		require.NotPanics(t, func() {
+			xerr := ledger.RevertToSnapshot(snap)
+			require.Error(t, xerr)
+			require.True(t, xerr.Contains(xerrors.ErrInvalidSnapshot))
+		})
+	})
+
+	t.Run("range", func(t *testing.T) {
+		snap := ledger.Snapshot()
+		snap.revision++
+
+		require.NotPanics(t, func() {
+			xerr := ledger.RevertToSnapshot(snap)
+			require.Error(t, xerr)
+			require.True(t, xerr.Contains(xerrors.ErrInvalidSnapshot))
+		})
+	})
+
+	t.Run("negative", func(t *testing.T) {
+		snap := ledger.Snapshot()
+		snap.revision = -1
+
+		require.NotPanics(t, func() {
+			xerr := ledger.RevertToSnapshot(snap)
+			require.Error(t, xerr)
+			require.True(t, xerr.Contains(xerrors.ErrInvalidSnapshot))
+		})
+	})
+}
+
+func TestMemLedger_SnapshotLifecycle(t *testing.T) {
+	newLedger := func(t *testing.T) *MemLedger {
+		t.Helper()
+
+		ledger, xerr := NewMemLedgerAt(1, sourceLedger, log.NewNopLogger())
+		require.NoError(t, xerr)
+		return ledger
+	}
+
+	t.Run("inner outer", func(t *testing.T) {
+		ledger := newLedger(t)
+		key := newItem(701, "").Key()
+
+		require.NoError(t, ledger.Set(key, newItem(701, "base")))
+		outer := ledger.Snapshot()
+		require.NoError(t, ledger.Set(key, newItem(701, "outer")))
+		inner := ledger.Snapshot()
+		require.NoError(t, ledger.Set(key, newItem(701, "inner")))
+
+		require.NoError(t, ledger.RevertToSnapshot(inner))
+		requireItemData(t, ledger, key, "outer")
+		require.NoError(t, ledger.RevertToSnapshot(outer))
+		requireItemData(t, ledger, key, "base")
+	})
+
+	t.Run("outer inner reject", func(t *testing.T) {
+		ledger := newLedger(t)
+		key := newItem(702, "").Key()
+
+		outer := ledger.Snapshot()
+		require.NoError(t, ledger.Set(key, newItem(702, "outer")))
+		inner := ledger.Snapshot()
+		require.NoError(t, ledger.Set(key, newItem(702, "inner")))
+
+		require.NoError(t, ledger.RevertToSnapshot(outer))
+		xerr := ledger.RevertToSnapshot(inner)
+		require.Error(t, xerr)
+		require.True(t, xerr.Contains(xerrors.ErrInvalidSnapshot))
+	})
+
+	t.Run("noop reuse", func(t *testing.T) {
+		ledger := newLedger(t)
+		key := newItem(703, "").Key()
+
+		snap := ledger.Snapshot()
+		require.NoError(t, ledger.Set(key, newItem(703, "created")))
+		require.NoError(t, ledger.RevertToSnapshot(snap))
+		require.NoError(t, ledger.RevertToSnapshot(snap))
+
+		_, xerr := ledger.Get(key)
+		require.Error(t, xerr)
+		require.True(t, xerr.Contains(xerrors.ErrNotFoundResult))
+	})
+
+	t.Run("reuse revision", func(t *testing.T) {
+		ledger := newLedger(t)
+		firstKey := newItem(704, "").Key()
+		secondKey := newItem(705, "").Key()
+
+		outer := ledger.Snapshot()
+		require.NoError(t, ledger.Set(firstKey, newItem(704, "first")))
+		oldInner := ledger.Snapshot()
+		require.NoError(t, ledger.RevertToSnapshot(outer))
+
+		require.NoError(t, ledger.Set(secondKey, newItem(705, "second")))
+		require.Equal(t, oldInner.revision, ledger.Snapshot().revision)
+		require.NoError(t, ledger.RevertToSnapshot(oldInner))
+		requireItemData(t, ledger, secondKey, "second")
+	})
 }

--- a/ledger/v1/mutable_ledger.go
+++ b/ledger/v1/mutable_ledger.go
@@ -196,34 +196,40 @@ func (ledger *MutableLedger) Del(key LedgerKey) xerrors.XError {
 	return nil
 }
 
-func (ledger *MutableLedger) Snapshot() int {
+func (ledger *MutableLedger) Snapshot() Snapshot {
 	ledger.mtx.RLock()
 	defer ledger.mtx.RUnlock()
 
 	return ledger.revisions.snapshot()
 }
 
-func (ledger *MutableLedger) RevertToSnapshot(snap int) xerrors.XError {
+func (ledger *MutableLedger) RevertToSnapshot(snap Snapshot) xerrors.XError {
 	ledger.mtx.Lock()
 	defer ledger.mtx.Unlock()
 
-	restores := ledger.revisions.revs[snap:]
+	if xerr := ledger.revisions.validateSnapshot(snap); xerr != nil {
+		return xerr
+	}
+
+	// A failed restore can leave the tree partially reverted. Do not allow
+	// callers to read objects cached from before the revert attempt.
+	ledger.cachedObjs = make(map[string]ILedgerItem)
+
+	restores := ledger.revisions.revs[snap.revision:]
 	for i := len(restores) - 1; i >= 0; i-- {
 		kv := restores[i]
 		if kv.val != nil {
 			if _, err := ledger.tree.Set(kv.key, kv.val); err != nil {
-				return xerrors.From(err)
+				return xerrors.ErrFatalLedger.Wrap(
+					xerrors.Wrap(err, "revert snapshot set failed"),
+				)
 			}
-			restoreItem := ledger.newItemFor(kv.key)
-			if xerr := restoreItem.Decode(kv.key, kv.val); xerr != nil {
-				return xerr
-			}
-			ledger.cachedObjs[unsafe.String(&kv.key[0], len(kv.key))] = restoreItem
 		} else {
 			if _, _, err := ledger.tree.Remove(kv.key); err != nil {
-				return xerrors.From(err)
+				return xerrors.ErrFatalLedger.Wrap(
+					xerrors.Wrap(err, "revert snapshot remove failed"),
+				)
 			}
-			delete(ledger.cachedObjs, unsafe.String(&kv.key[0], len(kv.key)))
 		}
 	}
 	ledger.revisions.revert(snap)

--- a/ledger/v1/mutable_ledger_test.go
+++ b/ledger/v1/mutable_ledger_test.go
@@ -2,8 +2,11 @@ package v1
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"github.com/beatoz/beatoz-go/types/xerrors"
+	"github.com/cosmos/iavl"
+	dbm "github.com/cosmos/iavl/db"
 	"github.com/stretchr/testify/require"
 	"github.com/tendermint/tendermint/libs/log"
 	"os"
@@ -67,12 +70,16 @@ func TestMutableLedger_RevertToSnapshot_Set1(t *testing.T) {
 	for i := 0; i < 10000; i++ {
 		oriItems = append(oriItems, newItem(i, fmt.Sprintf("origin:%d", i)))
 	}
-	for _, it := range oriItems {
+	var firstSnap Snapshot
+	for i, it := range oriItems {
 		require.NoError(t, ledger.Set(it.Key(), it))
+		if i == 0 {
+			firstSnap = ledger.Snapshot()
+		}
 	}
 
 	snap := ledger.Snapshot()
-	require.Equal(t, 10000, snap)
+	require.Equal(t, 10000, snap.revision)
 
 	var newItems []*Item
 	for i := 0; i < 10000; i++ {
@@ -100,7 +107,7 @@ func TestMutableLedger_RevertToSnapshot_Set1(t *testing.T) {
 		require.Equal(t, fmt.Sprintf("origin:%d", i), item.(*Item).data)
 	}
 
-	require.NoError(t, ledger.RevertToSnapshot(1))
+	require.NoError(t, ledger.RevertToSnapshot(firstSnap))
 	k := make([]byte, 4)
 	binary.BigEndian.PutUint32(k, uint32(0))
 	item, xerr := ledger.Get(k)
@@ -129,18 +136,21 @@ func TestMutableLedger_RevertToSnapshot_Set2(t *testing.T) {
 	require.NoError(t, xerr)
 
 	staticKey := 123
+	snapshots := make([]Snapshot, 10001)
+	snapshots[0] = ledger.Snapshot()
 	for i := 0; i < 10000; i++ {
 		// key 고정
 		item := newItem(staticKey, strconv.Itoa(i))
 		xerr := ledger.Set(item.Key(), item)
 		require.NoError(t, xerr)
+		snapshots[i+1] = ledger.Snapshot()
 	}
 
-	require.Equal(t, 10000, ledger.Snapshot())
+	require.Equal(t, 10000, ledger.Snapshot().revision)
 
 	for i := 10000; i >= 0; i-- {
 		// partially revert
-		require.NoError(t, ledger.RevertToSnapshot(i))
+		require.NoError(t, ledger.RevertToSnapshot(snapshots[i]))
 
 		k := make([]byte, 4)
 		binary.BigEndian.PutUint32(k, uint32(staticKey))
@@ -177,7 +187,7 @@ func TestMutableLedger_RevertToSnapshot_Set_Updated(t *testing.T) {
 	require.NoError(t, xerr)
 
 	snap := ledger.Snapshot()
-	require.Equal(t, 1, snap)
+	require.Equal(t, 1, snap.revision)
 
 	_item0, xerr := ledger.Get(item.Key())
 	require.NoError(t, xerr)
@@ -215,7 +225,7 @@ func TestMutableLedger_RevertToSnapshot_Del(t *testing.T) {
 
 	// get snapshot
 	snap := ledger.Snapshot()
-	require.Equal(t, 1, snap)
+	require.Equal(t, 1, snap.revision)
 
 	// delete item
 	require.NoError(t, ledger.Del(item.Key()))
@@ -231,6 +241,291 @@ func TestMutableLedger_RevertToSnapshot_Del(t *testing.T) {
 
 	require.NoError(t, ledger.Close())
 	require.NoError(t, os.RemoveAll(dbDir))
+}
+
+func TestMutableLedger_CommitReset(t *testing.T) {
+	dbDir := t.TempDir()
+	ledger, xerr := NewMutableLedger("ledger_test", dbDir, 100, func(key LedgerKey) ILedgerItem {
+		return &Item{}
+	}, log.NewNopLogger())
+	require.NoError(t, xerr)
+	t.Cleanup(func() {
+		require.NoError(t, ledger.Close())
+	})
+
+	item := newItem(456, "data456")
+	require.NoError(t, ledger.Set(item.Key(), item))
+	beforeCommit := ledger.Snapshot()
+	require.Equal(t, 1, beforeCommit.revision)
+
+	_, _, xerr = ledger.Commit()
+	require.NoError(t, xerr)
+	afterCommit := ledger.Snapshot()
+	require.Equal(t, 0, afterCommit.revision)
+	require.Equal(t, beforeCommit.ledgerID, afterCommit.ledgerID)
+	require.NotEqual(t, beforeCommit.generation, afterCommit.generation)
+}
+
+func TestMutableLedger_SnapshotIdentity(t *testing.T) {
+	firstLedger := newMutableLedgerForTest(t)
+	secondLedger := newMutableLedgerForTest(t)
+
+	first := firstLedger.Snapshot()
+	second := firstLedger.Snapshot()
+	otherLedger := secondLedger.Snapshot()
+
+	require.NotZero(t, first.ledgerID)
+	require.NotZero(t, first.generation)
+	require.Equal(t, first.ledgerID, second.ledgerID)
+	require.Equal(t, first.generation, second.generation)
+	require.Equal(t, first, second)
+	require.NotEqual(t, first.ledgerID, otherLedger.ledgerID)
+}
+
+func TestMutableLedger_InvalidSnapshot(t *testing.T) {
+	t.Run("zero", func(t *testing.T) {
+		ledger := newMutableLedgerForTest(t)
+
+		require.NotPanics(t, func() {
+			xerr := ledger.RevertToSnapshot(Snapshot{})
+			require.Error(t, xerr)
+			require.True(t, xerr.Contains(xerrors.ErrInvalidSnapshot))
+		})
+	})
+
+	t.Run("foreign", func(t *testing.T) {
+		ledger := newMutableLedgerForTest(t)
+		otherLedger := newMutableLedgerForTest(t)
+
+		require.NotPanics(t, func() {
+			xerr := ledger.RevertToSnapshot(otherLedger.Snapshot())
+			require.Error(t, xerr)
+			require.True(t, xerr.Contains(xerrors.ErrInvalidSnapshot))
+		})
+	})
+
+	t.Run("stale", func(t *testing.T) {
+		ledger := newMutableLedgerForTest(t)
+		require.NoError(t, ledger.Set(newItem(501, "").Key(), newItem(501, "committed")))
+		stale := ledger.Snapshot()
+		_, _, xerr := ledger.Commit()
+		require.NoError(t, xerr)
+
+		require.NotPanics(t, func() {
+			xerr = ledger.RevertToSnapshot(stale)
+			require.Error(t, xerr)
+			require.True(t, xerr.Contains(xerrors.ErrInvalidSnapshot))
+		})
+	})
+
+	t.Run("range", func(t *testing.T) {
+		ledger := newMutableLedgerForTest(t)
+		snap := ledger.Snapshot()
+		snap.revision = 1
+
+		require.NotPanics(t, func() {
+			xerr := ledger.RevertToSnapshot(snap)
+			require.Error(t, xerr)
+			require.True(t, xerr.Contains(xerrors.ErrInvalidSnapshot))
+		})
+	})
+
+	t.Run("negative", func(t *testing.T) {
+		ledger := newMutableLedgerForTest(t)
+		snap := ledger.Snapshot()
+		snap.revision = -1
+
+		require.NotPanics(t, func() {
+			xerr := ledger.RevertToSnapshot(snap)
+			require.Error(t, xerr)
+			require.True(t, xerr.Contains(xerrors.ErrInvalidSnapshot))
+		})
+	})
+}
+
+func TestMutableLedger_SnapshotLifecycle(t *testing.T) {
+	t.Run("inner outer", func(t *testing.T) {
+		ledger := newMutableLedgerForTest(t)
+		key := newItem(601, "").Key()
+
+		require.NoError(t, ledger.Set(key, newItem(601, "base")))
+		outer := ledger.Snapshot()
+		require.NoError(t, ledger.Set(key, newItem(601, "outer")))
+		inner := ledger.Snapshot()
+		require.NoError(t, ledger.Set(key, newItem(601, "inner")))
+
+		require.NoError(t, ledger.RevertToSnapshot(inner))
+		requireItemData(t, ledger, key, "outer")
+		require.NoError(t, ledger.RevertToSnapshot(outer))
+		requireItemData(t, ledger, key, "base")
+	})
+
+	t.Run("outer inner reject", func(t *testing.T) {
+		ledger := newMutableLedgerForTest(t)
+		key := newItem(602, "").Key()
+
+		outer := ledger.Snapshot()
+		require.NoError(t, ledger.Set(key, newItem(602, "outer")))
+		inner := ledger.Snapshot()
+		require.NoError(t, ledger.Set(key, newItem(602, "inner")))
+
+		require.NoError(t, ledger.RevertToSnapshot(outer))
+		xerr := ledger.RevertToSnapshot(inner)
+		require.Error(t, xerr)
+		require.True(t, xerr.Contains(xerrors.ErrInvalidSnapshot))
+	})
+
+	t.Run("noop reuse", func(t *testing.T) {
+		ledger := newMutableLedgerForTest(t)
+		key := newItem(603, "").Key()
+
+		snap := ledger.Snapshot()
+		require.NoError(t, ledger.Set(key, newItem(603, "created")))
+		require.NoError(t, ledger.RevertToSnapshot(snap))
+		require.NoError(t, ledger.RevertToSnapshot(snap))
+
+		_, xerr := ledger.Get(key)
+		require.Error(t, xerr)
+		require.True(t, xerr.Contains(xerrors.ErrNotFoundResult))
+	})
+
+	t.Run("reuse revision", func(t *testing.T) {
+		ledger := newMutableLedgerForTest(t)
+		firstKey := newItem(604, "").Key()
+		secondKey := newItem(605, "").Key()
+
+		outer := ledger.Snapshot()
+		require.NoError(t, ledger.Set(firstKey, newItem(604, "first")))
+		oldInner := ledger.Snapshot()
+		require.NoError(t, ledger.RevertToSnapshot(outer))
+
+		require.NoError(t, ledger.Set(secondKey, newItem(605, "second")))
+		require.Equal(t, oldInner.revision, ledger.Snapshot().revision)
+		require.NoError(t, ledger.RevertToSnapshot(oldInner))
+		requireItemData(t, ledger, secondKey, "second")
+	})
+}
+
+func TestMutableLedger_RevertCache(t *testing.T) {
+	ledger := newMutableLedgerForTest(t)
+	key := newItem(606, "").Key()
+
+	require.NoError(t, ledger.Set(key, newItem(606, "persisted")))
+	_, _, xerr := ledger.Commit()
+	require.NoError(t, xerr)
+
+	cached, xerr := ledger.Get(key)
+	require.NoError(t, xerr)
+	snap := ledger.Snapshot()
+
+	cached.(*Item).data = "mutated-without-set"
+	require.Equal(t, "mutated-without-set", cached.(*Item).data)
+
+	require.NoError(t, ledger.RevertToSnapshot(snap))
+
+	reloaded, xerr := ledger.Get(key)
+	require.NoError(t, xerr)
+	require.Equal(t, "persisted", reloaded.(*Item).data)
+	require.NotSame(t, cached, reloaded)
+}
+
+func TestMutableLedger_RevertFatal(t *testing.T) {
+	t.Run("set", func(t *testing.T) {
+		ledger, failingDB := newFailingReadLedger(t)
+		key := newItem(901, "").Key()
+		snap := ledger.Snapshot()
+		ledger.revisions.set(key, []byte("old-value"))
+		ledger.cachedObjs[string(key)] = newItem(901, "cached")
+		revisionCount := len(ledger.revisions.revs)
+
+		failingDB.failReads = true
+		xerr := ledger.RevertToSnapshot(snap)
+
+		require.Error(t, xerr)
+		require.True(t, xerr.Contains(xerrors.ErrFatalLedger))
+		require.Contains(t, xerr.Error(), "revert snapshot set failed")
+		require.Empty(t, ledger.cachedObjs)
+		require.Len(t, ledger.revisions.revs, revisionCount)
+	})
+
+	t.Run("remove", func(t *testing.T) {
+		ledger, failingDB := newFailingReadLedger(t)
+		key := newItem(902, "").Key()
+		snap := ledger.Snapshot()
+		ledger.revisions.set(key, nil)
+		ledger.cachedObjs[string(key)] = newItem(902, "cached")
+		revisionCount := len(ledger.revisions.revs)
+
+		failingDB.failReads = true
+		xerr := ledger.RevertToSnapshot(snap)
+
+		require.Error(t, xerr)
+		require.True(t, xerr.Contains(xerrors.ErrFatalLedger))
+		require.Contains(t, xerr.Error(), "revert snapshot remove failed")
+		require.Empty(t, ledger.cachedObjs)
+		require.Len(t, ledger.revisions.revs, revisionCount)
+	})
+}
+
+func requireItemData(t *testing.T, ledger IGettable, key LedgerKey, want string) {
+	t.Helper()
+
+	item, xerr := ledger.Get(key)
+	require.NoError(t, xerr)
+	require.Equal(t, want, item.(*Item).data)
+}
+
+func newMutableLedgerForTest(t *testing.T) *MutableLedger {
+	t.Helper()
+
+	ledger, xerr := NewMutableLedger("ledger_test", t.TempDir(), 100, func(key LedgerKey) ILedgerItem {
+		return &Item{}
+	}, log.NewNopLogger())
+	require.NoError(t, xerr)
+	t.Cleanup(func() {
+		require.NoError(t, ledger.Close())
+	})
+	return ledger
+}
+
+type failingReadDB struct {
+	dbm.DB
+	failReads bool
+}
+
+func (db *failingReadDB) Get(key []byte) ([]byte, error) {
+	if db.failReads {
+		return nil, errors.New("injected IAVL read failure")
+	}
+	return db.DB.Get(key)
+}
+
+func newFailingReadLedger(t *testing.T) (*MutableLedger, *failingReadDB) {
+	t.Helper()
+
+	baseDB := dbm.NewMemDB()
+	sourceTree := iavl.NewMutableTree(baseDB, 0, true, iavl.NewNopLogger())
+	for i := 900; i < 904; i++ {
+		_, err := sourceTree.Set(newItem(i, "").Key(), []byte(fmt.Sprintf("value-%d", i)))
+		require.NoError(t, err)
+	}
+	_, version, err := sourceTree.SaveVersion()
+	require.NoError(t, err)
+
+	failingDB := &failingReadDB{DB: baseDB}
+	tree := iavl.NewMutableTree(failingDB, 0, true, iavl.NewNopLogger())
+	_, err = tree.LoadVersion(version)
+	require.NoError(t, err)
+
+	return &MutableLedger{
+		db:         failingDB,
+		tree:       tree,
+		revisions:  newSnapshotList[[]byte](),
+		cachedObjs: make(map[string]ILedgerItem),
+		newItemFor: func(key LedgerKey) ILedgerItem { return &Item{} },
+		cacheSize:  0,
+		logger:     log.NewNopLogger(),
+	}, failingDB
 }
 
 type Item struct {

--- a/ledger/v1/revision_list.go
+++ b/ledger/v1/revision_list.go
@@ -28,6 +28,7 @@ func newSnapshotList[T any]() *revisionList[T] {
 		generation: 1,
 	}
 }
+
 func (revlist *revisionList[T]) set(key []byte, val T) {
 	revlist.revs = append(revlist.revs, &kvPair[T]{
 		key: key,

--- a/ledger/v1/revision_list.go
+++ b/ledger/v1/revision_list.go
@@ -1,17 +1,31 @@
 package v1
 
+import (
+	"sync/atomic"
+
+	"github.com/beatoz/beatoz-go/types/xerrors"
+)
+
 type kvPair[T any] struct {
 	key []byte
 	val T
 }
 
 type revisionList[T any] struct {
-	revs []*kvPair[T]
+	revs       []*kvPair[T]
+	ledgerID   uint64
+	generation uint64
 }
+
+// nextLedgerID issues process-local IDs used only to reject snapshots
+// created by a different ledger instance.
+var nextLedgerID uint64
 
 func newSnapshotList[T any]() *revisionList[T] {
 	return &revisionList[T]{
-		revs: make([]*kvPair[T], 0),
+		revs:       make([]*kvPair[T], 0),
+		ledgerID:   atomic.AddUint64(&nextLedgerID, 1),
+		generation: 1,
 	}
 }
 func (revlist *revisionList[T]) set(key []byte, val T) {
@@ -21,16 +35,46 @@ func (revlist *revisionList[T]) set(key []byte, val T) {
 	})
 }
 
-func (revlist revisionList[T]) snapshot() int {
-	return len(revlist.revs)
+func (revlist revisionList[T]) snapshot() Snapshot {
+	return Snapshot{
+		ledgerID:   revlist.ledgerID,
+		generation: revlist.generation,
+		revision:   len(revlist.revs),
+	}
 }
 
-func (revlist *revisionList[T]) revert(snap int) {
-	revlist.revs = revlist.revs[:snap]
+func (revlist revisionList[T]) validateSnapshot(snap Snapshot) xerrors.XError {
+	if snap.ledgerID != revlist.ledgerID {
+		return xerrors.ErrInvalidSnapshot.Wrapf(
+			"ledger ID mismatch: snapshot=%d, ledger=%d",
+			snap.ledgerID,
+			revlist.ledgerID,
+		)
+	}
+	if snap.generation != revlist.generation {
+		return xerrors.ErrInvalidSnapshot.Wrapf(
+			"generation mismatch: snapshot=%d, ledger=%d",
+			snap.generation,
+			revlist.generation,
+		)
+	}
+	if snap.revision < 0 || snap.revision > len(revlist.revs) {
+		return xerrors.ErrInvalidSnapshot.Wrapf(
+			"revision out of range: snapshot=%d, revisions=%d",
+			snap.revision,
+			len(revlist.revs),
+		)
+	}
+	return nil
 }
 
-func (revlist revisionList[T]) reset() {
+func (revlist *revisionList[T]) revert(snap Snapshot) {
+	revlist.revs = revlist.revs[:snap.revision]
+}
+
+func (revlist *revisionList[T]) reset() {
 	revlist.revs = revlist.revs[:0]
+	revlist.generation++
 }
 
 func (revlist revisionList[T]) iterate(cb func(idx int, kv *kvPair[T]) bool) {

--- a/ledger/v1/state_ledger.go
+++ b/ledger/v1/state_ledger.go
@@ -94,14 +94,14 @@ func (ledger *StateLedger) Del(key LedgerKey, exec bool) xerrors.XError {
 	return nil
 }
 
-func (ledger *StateLedger) Snapshot(exec bool) int {
+func (ledger *StateLedger) Snapshot(exec bool) Snapshot {
 	ledger.mtx.RLock()
 	defer ledger.mtx.RUnlock()
 
 	return ledger.getLedger(exec).Snapshot()
 }
 
-func (ledger *StateLedger) RevertToSnapshot(snap int, exec bool) xerrors.XError {
+func (ledger *StateLedger) RevertToSnapshot(snap Snapshot, exec bool) xerrors.XError {
 	ledger.mtx.RLock()
 	defer ledger.mtx.RUnlock()
 

--- a/ledger/v1/state_ledger_test.go
+++ b/ledger/v1/state_ledger_test.go
@@ -1,0 +1,81 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/beatoz/beatoz-go/types/xerrors"
+	"github.com/stretchr/testify/require"
+	"github.com/tendermint/tendermint/libs/log"
+)
+
+func TestStateLedger_SnapshotDelegatesByExecMode(t *testing.T) {
+	ledger, xerr := NewStateLedger("state_ledger_test", t.TempDir(), 100, func(key LedgerKey) ILedgerItem {
+		return &Item{}
+	}, log.NewNopLogger())
+	require.NoError(t, xerr)
+	t.Cleanup(func() {
+		require.NoError(t, ledger.Close())
+	})
+
+	require.NoError(t, ledger.Set(newItem(800, "").Key(), newItem(800, "base"), true))
+	_, _, xerr = ledger.Commit()
+	require.NoError(t, xerr)
+
+	execKey := newItem(801, "").Key()
+	simulationKey := newItem(802, "").Key()
+	execSnap := ledger.Snapshot(true)
+	simulationSnap := ledger.Snapshot(false)
+
+	require.NoError(t, ledger.Set(execKey, newItem(801, "exec"), true))
+	require.NoError(t, ledger.Set(simulationKey, newItem(802, "simulation"), false))
+
+	require.NoError(t, ledger.RevertToSnapshot(execSnap, true))
+	_, xerr = ledger.Get(execKey, true)
+	require.Error(t, xerr)
+	require.True(t, xerr.Contains(xerrors.ErrNotFoundResult))
+	requireStateItemData(t, ledger, simulationKey, "simulation", false)
+
+	require.NoError(t, ledger.RevertToSnapshot(simulationSnap, false))
+	_, xerr = ledger.Get(simulationKey, false)
+	require.Error(t, xerr)
+	require.True(t, xerr.Contains(xerrors.ErrNotFoundResult))
+}
+
+func TestStateLedger_RejectsSnapshotFromOtherExecMode(t *testing.T) {
+	ledger, xerr := NewStateLedger("state_ledger_test", t.TempDir(), 100, func(key LedgerKey) ILedgerItem {
+		return &Item{}
+	}, log.NewNopLogger())
+	require.NoError(t, xerr)
+	t.Cleanup(func() {
+		require.NoError(t, ledger.Close())
+	})
+
+	require.NoError(t, ledger.Set(newItem(810, "").Key(), newItem(810, "base"), true))
+	_, _, xerr = ledger.Commit()
+	require.NoError(t, xerr)
+
+	execSnap := ledger.Snapshot(true)
+	simulationSnap := ledger.Snapshot(false)
+
+	xerr = ledger.RevertToSnapshot(execSnap, false)
+	require.Error(t, xerr)
+	require.True(t, xerr.Contains(xerrors.ErrInvalidSnapshot))
+
+	xerr = ledger.RevertToSnapshot(simulationSnap, true)
+	require.Error(t, xerr)
+	require.True(t, xerr.Contains(xerrors.ErrInvalidSnapshot))
+}
+
+func requireStateItemData(
+	t *testing.T,
+	ledger *StateLedger,
+	key LedgerKey,
+	want string,
+	exec bool,
+) {
+	t.Helper()
+
+	item, xerr := ledger.Get(key, exec)
+	require.NoError(t, xerr)
+	require.Equal(t, want, item.(*Item).data)
+}

--- a/ledger/v1/types.go
+++ b/ledger/v1/types.go
@@ -10,6 +10,14 @@ import (
 type FuncNewItemFor func(LedgerKey) ILedgerItem
 type FuncIterate func(LedgerKey, ILedgerItem) xerrors.XError
 
+// Snapshot is an opaque handle to a ledger revision position.
+// Its lifecycle and validity are managed by the ledger that issued it.
+type Snapshot struct {
+	ledgerID   uint64
+	generation uint64
+	revision   int
+}
+
 type IGettable interface {
 	Get(LedgerKey) (ILedgerItem, xerrors.XError)
 	Iterate(FuncIterate) xerrors.XError
@@ -19,8 +27,8 @@ type IGettable interface {
 type ISettable interface {
 	Set(LedgerKey, ILedgerItem) xerrors.XError
 	Del(LedgerKey) xerrors.XError
-	Snapshot() int
-	RevertToSnapshot(int) xerrors.XError
+	Snapshot() Snapshot
+	RevertToSnapshot(Snapshot) xerrors.XError
 }
 
 type ICommittable interface {
@@ -47,8 +55,8 @@ type IStateLedger interface {
 	Iterate(FuncIterate, bool) xerrors.XError
 	Seek([]byte, bool, FuncIterate, bool) xerrors.XError
 	Set(LedgerKey, ILedgerItem, bool) xerrors.XError
-	Snapshot(bool) int
-	RevertToSnapshot(int, bool) xerrors.XError
+	Snapshot(bool) Snapshot
+	RevertToSnapshot(Snapshot, bool) xerrors.XError
 	Del(LedgerKey, bool) xerrors.XError
 	Commit() ([]byte, int64, xerrors.XError)
 	Close() xerrors.XError

--- a/node/trx_executor.go
+++ b/node/trx_executor.go
@@ -153,7 +153,7 @@ func runTrx(ctx *ctrlertypes.TrxContext) xerrors.XError {
 	if xerr != nil && rollbackEnabled {
 		executeErr := xerr
 		if rollbackErr := revertTrxLedgers(snaps, ctx.Exec); rollbackErr != nil {
-			return rollbackErr.Wrap(executeErr)
+			panic(rollbackErr.Wrap(executeErr))
 		}
 		if reloadErr := reloadTrxAccounts(ctx); reloadErr != nil {
 			return reloadErr.Wrap(executeErr)

--- a/node/trx_executor.go
+++ b/node/trx_executor.go
@@ -1,9 +1,11 @@
 package node
 
 import (
+	"errors"
 	"fmt"
 
 	ctrlertypes "github.com/beatoz/beatoz-go/ctrlers/types"
+	v1 "github.com/beatoz/beatoz-go/ledger/v1"
 	"github.com/beatoz/beatoz-go/types"
 	"github.com/beatoz/beatoz-go/types/bytes"
 	"github.com/beatoz/beatoz-go/types/xerrors"
@@ -14,6 +16,11 @@ import (
 type TrxExecutor struct {
 	*TrxPreparer
 	logger log.Logger
+}
+
+type trxLedgerSnapshot struct {
+	handler ctrlertypes.ITrxLedgerSnapshotter
+	snap    v1.Snapshot
 }
 
 func NewTrxExecutor(logger log.Logger) *TrxExecutor {
@@ -111,46 +118,131 @@ func validateTrx(ctx *ctrlertypes.TrxContext) xerrors.XError {
 }
 
 func runTrx(ctx *ctrlertypes.TrxContext) xerrors.XError {
-	var xerr xerrors.XError
-	defer func() {
-		if ctx.Exec || xerr == nil {
-			_xerr0 := postRunTrx(ctx)
-			if xerr != nil {
-				xerr = xerr.Wrap(_xerr0)
-			} else {
-				xerr = _xerr0
-			}
-		}
-	}()
+	snaps, rollbackEnabled := snapshotTrxLedgers(ctx)
 
+	var xerr xerrors.XError
 	switch ctx.Tx.GetType() {
 	case ctrlertypes.TRX_CONTRACT:
 		if xerr = ctx.EVMHandler.ExecuteTrx(ctx); xerr != nil {
-			return xerr
+			break
 		}
 	case ctrlertypes.TRX_PROPOSAL, ctrlertypes.TRX_VOTING:
 		if xerr = ctx.GovHandler.ExecuteTrx(ctx); xerr != nil {
-			return xerr
+			break
 		}
 	case ctrlertypes.TRX_TRANSFER, ctrlertypes.TRX_SETDOC:
 		if ctx.IsHandledByEVM() {
 			if xerr = ctx.EVMHandler.ExecuteTrx(ctx); xerr != nil {
-				return xerr
+				break
 			}
 		} else if xerr = ctx.AcctHandler.ExecuteTrx(ctx); xerr != nil {
-			return xerr
+			break
 		}
 	case ctrlertypes.TRX_WITHDRAW:
 		if xerr = ctx.SupplyHandler.ExecuteTrx(ctx); xerr != nil {
-			return xerr
+			break
 		}
 	case ctrlertypes.TRX_STAKING, ctrlertypes.TRX_UNSTAKING:
 		if xerr = ctx.VPowerHandler.ExecuteTrx(ctx); xerr != nil {
-			return xerr
+			break
 		}
 	default:
-		return xerrors.ErrUnknownTrxType
+		xerr = xerrors.ErrUnknownTrxType
 	}
+
+	if xerr != nil && rollbackEnabled {
+		executeErr := xerr
+		if rollbackErr := revertTrxLedgers(snaps, ctx.Exec); rollbackErr != nil {
+			return rollbackErr.Wrap(executeErr)
+		}
+		if reloadErr := reloadTrxAccounts(ctx); reloadErr != nil {
+			return reloadErr.Wrap(executeErr)
+		}
+		xerr = executeErr
+	}
+	if !ctx.Exec && xerr != nil {
+		return xerr
+	}
+
+	postErr := postRunTrx(ctx)
+	if postErr == nil {
+		return xerr
+	}
+	if xerr != nil {
+		return xerr.Wrap(postErr)
+	}
+	return postErr
+}
+
+func snapshotTrxLedgers(ctx *ctrlertypes.TrxContext) ([]trxLedgerSnapshot, bool) {
+	if ctx.IsHandledByEVM() {
+		return nil, false
+	}
+
+	handlers := trxSnapshotHandlers(ctx)
+	snaps := make([]trxLedgerSnapshot, 0, len(handlers))
+	for _, handler := range handlers {
+		snapshotter, ok := handler.(ctrlertypes.ITrxLedgerSnapshotter)
+		if !ok {
+			continue
+		}
+		snaps = append(snaps, trxLedgerSnapshot{
+			handler: snapshotter,
+			snap:    snapshotter.Snapshot(ctx.Exec),
+		})
+	}
+	return snaps, true
+}
+
+func trxSnapshotHandlers(ctx *ctrlertypes.TrxContext) []interface{} {
+	// Snapshot every non-EVM controller so rollback does not depend on static tx write-set mapping.
+	return []interface{}{
+		ctx.AcctHandler,
+		ctx.GovHandler,
+		ctx.SupplyHandler,
+		ctx.VPowerHandler,
+	}
+}
+
+func revertTrxLedgers(snaps []trxLedgerSnapshot, exec bool) xerrors.XError {
+	for i := len(snaps) - 1; i >= 0; i-- {
+		if xerr := snaps[i].handler.RevertToSnapshot(snaps[i].snap, exec); xerr != nil {
+			return xerr
+		}
+	}
+	return nil
+}
+
+func reloadTrxAccounts(ctx *ctrlertypes.TrxContext) xerrors.XError {
+	sender := ctx.AcctHandler.FindAccount(ctx.Tx.From, ctx.Exec)
+	if sender == nil {
+		return xerrors.ErrNotFoundAccount.Wrapf("sender address: %v", ctx.Tx.From)
+	}
+	ctx.Sender = sender
+
+	if ctx.Tx.PayerSig != nil {
+		payerAddr, _, xerr := ctrlertypes.VerifyPayerTrxRLP(ctx.Tx)
+		if xerr != nil {
+			return xerr.Wrap(errors.New("payer signature is invalid"))
+		}
+		payer := ctx.AcctHandler.FindAccount(payerAddr, ctx.Exec)
+		if payer == nil {
+			return xerrors.ErrNotFoundAccount.Wrapf("payer address: %v", payerAddr)
+		}
+		ctx.Payer = payer
+	} else {
+		ctx.Payer = ctx.Sender
+	}
+
+	toAddr := ctx.Tx.To
+	if toAddr == nil {
+		toAddr = types.ZeroAddress()
+	}
+	receiver := ctx.AcctHandler.FindOrNewAccount(toAddr, ctx.Exec)
+	if receiver == nil {
+		return xerrors.ErrNotFoundAccount.Wrapf("receiver address: %v", toAddr)
+	}
+	ctx.Receiver = receiver
 
 	return nil
 }

--- a/node/trx_executor_test.go
+++ b/node/trx_executor_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/beatoz/beatoz-go/ctrlers/mocks/acct"
 	"github.com/beatoz/beatoz-go/ctrlers/mocks/gov"
 	ctrlertypes "github.com/beatoz/beatoz-go/ctrlers/types"
+	v1 "github.com/beatoz/beatoz-go/ledger/v1"
 	"github.com/beatoz/beatoz-go/types"
 	"github.com/beatoz/beatoz-go/types/xerrors"
 	"github.com/beatoz/beatoz-sdk-go/web3"
@@ -313,4 +314,153 @@ func Test_Payer(t *testing.T) {
 
 	actualSender = acctMock.FindAccount(sender.Address(), true)
 	require.Equal(t, expectedSenderBalance.Dec(), actualSender.GetBalance().Dec())
+}
+
+func Test_RunTrx_Rollback(t *testing.T) {
+	t.Run("failed_non_evm", func(t *testing.T) {
+		sender := web3.NewWallet(nil)
+		receiver := web3.NewWallet(nil)
+		gas := govMock.MinTrxGas()
+		amt := uint256.NewInt(100)
+		senderBalance := uint256.NewInt(balance)
+
+		acctHandler := newFailingAcctHandler(
+			accountWithBalance(sender.Address(), senderBalance),
+			accountWithBalance(receiver.Address(), uint256.NewInt(0)),
+		)
+		acctHandler.executeErr = xerrors.ErrInvalidTrx
+		bctx := mocks.InitBlockCtxWith(chainId.Hex(), 1, govMock, acctHandler, nil, nil, nil)
+		bctx.SetBlockGasLimit(gas * 10)
+
+		tx := web3.NewTrxTransfer(sender.Address(), receiver.Address(), 0, gas, govMock.GasPrice(), amt)
+		_, _, err := sender.SignTrxRLP(tx, chainId.Hex())
+		require.NoError(t, err)
+		txctx, xerr := mocks.MakeTrxCtxWithTrxBctx(tx, bctx, true)
+		require.NoError(t, xerr)
+
+		xerr = runTrx(txctx)
+		require.Error(t, xerr)
+		require.Equal(t, 1, acctHandler.SnapshotCount())
+		require.Equal(t, 1, acctHandler.RevertCount())
+		require.Equal(t, gas, txctx.GasUsed)
+		require.Equal(t, gas, bctx.GetBlockGasUsed())
+
+		fee := types.GasToFee(gas, govMock.GasPrice())
+		expectedSenderBalance := new(uint256.Int).Sub(senderBalance, fee)
+		actualSender := acctHandler.FindAccount(sender.Address(), true)
+		require.Equal(t, expectedSenderBalance.Dec(), actualSender.GetBalance().Dec())
+		require.Equal(t, int64(1), actualSender.GetNonce())
+
+		actualReceiver := acctHandler.FindAccount(receiver.Address(), true)
+		require.Equal(t, "0", actualReceiver.GetBalance().Dec())
+	})
+
+	t.Run("rollback_panic", func(t *testing.T) {
+		sender := web3.NewWallet(nil)
+		receiver := web3.NewWallet(nil)
+		gas := govMock.MinTrxGas()
+
+		acctHandler := newFailingAcctHandler(
+			accountWithBalance(sender.Address(), uint256.NewInt(balance)),
+			accountWithBalance(receiver.Address(), uint256.NewInt(0)),
+		)
+		acctHandler.executeErr = xerrors.ErrInvalidTrx
+		acctHandler.revertErr = xerrors.ErrInvalidSnapshot
+		bctx := mocks.InitBlockCtxWith(chainId.Hex(), 1, govMock, acctHandler, nil, nil, nil)
+		bctx.SetBlockGasLimit(gas * 10)
+
+		tx := web3.NewTrxTransfer(sender.Address(), receiver.Address(), 0, gas, govMock.GasPrice(), uint256.NewInt(100))
+		_, _, err := sender.SignTrxRLP(tx, chainId.Hex())
+		require.NoError(t, err)
+		txctx, xerr := mocks.MakeTrxCtxWithTrxBctx(tx, bctx, true)
+		require.NoError(t, xerr)
+
+		require.Panics(t, func() {
+			_ = runTrx(txctx)
+		})
+		require.Equal(t, int64(0), bctx.GetBlockGasUsed())
+	})
+
+	t.Run("evm_skip", func(t *testing.T) {
+		sender := web3.NewWallet(nil)
+		receiver := web3.NewWallet(nil)
+		gas := govMock.MinTrxGas()
+		receiverAcct := accountWithBalance(receiver.Address(), uint256.NewInt(0))
+		receiverAcct.SetCode([]byte{0x01})
+
+		acctHandler := newFailingAcctHandler(
+			accountWithBalance(sender.Address(), uint256.NewInt(balance)),
+			receiverAcct,
+		)
+		evmHandler := &errEVMHandler{xerr: xerrors.ErrInvalidTrx}
+		bctx := mocks.InitBlockCtxWith(chainId.Hex(), 1, govMock, acctHandler, evmHandler, nil, nil)
+		bctx.SetBlockGasLimit(gas * 10)
+
+		tx := web3.NewTrxTransfer(sender.Address(), receiver.Address(), 0, gas, govMock.GasPrice(), uint256.NewInt(100))
+		_, _, err := sender.SignTrxRLP(tx, chainId.Hex())
+		require.NoError(t, err)
+		txctx, xerr := mocks.MakeTrxCtxWithTrxBctx(tx, bctx, false)
+		require.NoError(t, xerr)
+
+		require.Error(t, runTrx(txctx))
+		require.Equal(t, 0, acctHandler.SnapshotCount())
+		require.Equal(t, 1, evmHandler.executeCount)
+		require.Equal(t, int64(0), bctx.GetBlockGasUsed())
+	})
+}
+
+type failingAcctHandler struct {
+	*acct.AcctHandlerMock
+	executeErr xerrors.XError
+	revertErr  xerrors.XError
+}
+
+func newFailingAcctHandler(accounts ...*ctrlertypes.Account) *failingAcctHandler {
+	ret := &failingAcctHandler{
+		AcctHandlerMock: acct.NewAcctHandlerMock(0),
+	}
+	for _, acct := range accounts {
+		ret.AddAccount(acct.Clone())
+	}
+	return ret
+}
+
+func accountWithBalance(addr types.Address, balance *uint256.Int) *ctrlertypes.Account {
+	acct := ctrlertypes.NewAccount(addr)
+	acct.SetBalance(balance)
+	return acct
+}
+
+func (handler *failingAcctHandler) RevertToSnapshot(snap v1.Snapshot, exec bool) xerrors.XError {
+	if handler.revertErr != nil {
+		return handler.revertErr
+	}
+	return handler.AcctHandlerMock.RevertToSnapshot(snap, exec)
+}
+
+func (handler *failingAcctHandler) ExecuteTrx(ctx *ctrlertypes.TrxContext) xerrors.XError {
+	if xerr := ctx.Sender.SubBalance(ctx.Tx.Amount); xerr != nil {
+		return xerr
+	}
+	if xerr := handler.SetAccount(ctx.Sender, ctx.Exec); xerr != nil {
+		return xerr
+	}
+	if handler.executeErr != nil {
+		return handler.executeErr
+	}
+	if xerr := ctx.Receiver.AddBalance(ctx.Tx.Amount); xerr != nil {
+		return xerr
+	}
+	return handler.SetAccount(ctx.Receiver, ctx.Exec)
+}
+
+type errEVMHandler struct {
+	ctrlertypes.IEVMHandler
+	xerr         xerrors.XError
+	executeCount int
+}
+
+func (handler *errEVMHandler) ExecuteTrx(*ctrlertypes.TrxContext) xerrors.XError {
+	handler.executeCount++
+	return handler.xerr
 }

--- a/types/xerrors/xerror.go
+++ b/types/xerrors/xerror.go
@@ -81,6 +81,8 @@ var (
 	ErrNotVotingPeriod       = NewOrdinary("not voting period")
 	ErrDuplicatedKey         = NewOrdinary("already existed key")
 	ErrInvalidWeight         = NewOrdinary("invalid weight")
+	ErrInvalidSnapshot       = NewOrdinary("invalid ledger snapshot")
+	ErrFatalLedger           = NewOrdinary("fatal ledger error")
 )
 
 type XError interface {

--- a/types/xerrors/xerror_test.go
+++ b/types/xerrors/xerror_test.go
@@ -36,6 +36,12 @@ func Test_Contains(t *testing.T) {
 	require.False(t, xerr1.Contains(xerrNotContained))
 }
 
+func Test_FatalLedger(t *testing.T) {
+	xerr := ErrFatalLedger.Wrap(errors.New("revert snapshot set failed"))
+
+	require.True(t, xerr.Contains(ErrFatalLedger))
+}
+
 func Test_Equal(t *testing.T) {
 	xerr := ErrNotFoundResult
 	require.Equal(t, ErrNotFoundResult, xerr)


### PR DESCRIPTION
# BG-595 Design Review: Non-EVM Transaction Rollback

## Purpose

BG-595는 non-EVM transaction 실행에 transaction-level rollback boundary를 추가한다.

기존 구조에서는 controller `ExecuteTrx()`가 여러 ledger state를 순차적으로 변경하다가 중간에 실패하면, 이미 반영된 앞 단계의 변경이 남을 수 있었다. 대표 사례는 `TRX_WITHDRAW`에서 reward state를 먼저 차감한 뒤 account reward 지급이 실패하면 reward state만 변경되어 남는 경우다.

이번 변경의 목표는 다음과 같다.

- non-EVM transaction 실패 시 Account/Gov/Supply/VPower ledger state를 transaction 시작 시점으로 되돌린다.
- 실패한 DeliverTx의 fee/nonce 반영 정책은 기존처럼 유지한다.
- EVM-handled transaction은 기존 EVM rollback 경로를 유지한다.
- rollback boundary로 사용할 수 있도록 ledger snapshot/revert contract를 강화한다.

## High-Level Flow

non-EVM transaction 실행 흐름은 다음 순서로 바뀐다.

```text
validateTrx(ctx)
  -> runTrx(ctx)
       -> snapshotTrxLedgers(ctx)
       -> controller.ExecuteTrx(ctx)
       -> if ExecuteTrx failed:
            -> revertTrxLedgers(snaps, ctx.Exec)
            -> reloadTrxAccounts(ctx)
       -> if CheckTx failed:
            -> return original execute error
       -> postRunTrx(ctx)
       -> return original execute error or post-run error
```

핵심은 `ExecuteTrx()` 실패 후 controller/module state는 rollback하지만, DeliverTx(`ctx.Exec == true`)에서는 `postRunTrx()`를 계속 실행해서 failed tx fee/nonce를 반영한다는 점이다.

## Snapshot Definition

`ledger/v1.Snapshot`은 ledger revision 위치를 나타내는 opaque handle이다.

```go
type Snapshot struct {
    ledgerID   uint64
    generation uint64
    revision   int
}
```

필드 의미:

- `ledgerID`: snapshot을 발급한 ledger instance 식별자
- `generation`: commit/reset 이후 stale snapshot을 구분하기 위한 lifecycle 값
- `revision`: 현재 generation 안에서 revision list의 위치

외부 package는 snapshot 내부 값을 해석하거나 생성하지 않고, `Snapshot()`에서 받은 값을 그대로 `RevertToSnapshot()`에 전달하는 용도로만 사용한다. 필드가 unexported인 이유도 이 contract를 강제하기 위해서다.

## Snapshot Contract

snapshot/revert가 transaction rollback boundary로 쓰이려면 다음 조건이 필요하다.

- snapshot 이후 생성된 key는 revert 시 제거된다.
- snapshot 이후 수정된 key는 이전 serialized value로 복구된다.
- snapshot 이후 삭제된 key는 이전 serialized value로 복구된다.
- nested snapshot은 inner/outer 순서로 revert할 수 있다.
- 이미 revert되어 현재 revision 범위 밖이 된 snapshot은 거부된다.
- commit/reset 이전 generation의 stale snapshot은 거부된다.
- 다른 ledger instance에서 생성된 snapshot은 거부된다.
- exec=true ledger snapshot과 exec=false ledger snapshot은 서로 섞어 쓸 수 없다.
- invalid snapshot은 panic이 아니라 `ErrInvalidSnapshot`으로 반환된다.

이 contract를 위해 `revisionList`가 `ledgerID`, `generation`, `revision`을 함께 검증한다.

## Ledger Implementation

### Revision List

각 ledger는 `revisionList`를 가진다. `Set()` 또는 `Del()`은 변경 전 값을 revision list에 저장한다.

`Snapshot()`은 현재 revision list 길이를 포함한 handle을 반환한다. `RevertToSnapshot()`은 snapshot 이후 revision들을 역순으로 적용한 뒤 revision list를 snapshot 위치까지 줄인다.

`reset()`은 commit 이후 revision history를 비우고 generation을 증가시킨다. generation 증가로 commit 이전 snapshot은 같은 revision index를 갖더라도 이후 revert에서 stale snapshot으로 거부된다.

### MutableLedger

`MutableLedger`는 committed execution ledger다.

revert 절차:

1. snapshot validation
2. cached object map 전체 clear
3. snapshot 이후 revisions를 역순 restore
4. restore 성공 후 revision list truncate

cache를 전체 clear하는 이유는 rollback 이전에 caller가 들고 있던 object pointer가 `Set()` 없이 mutation되었을 수 있기 때문이다. serialized tree state는 rollback되더라도 cache가 남아 있으면 이후 `Get()`이 stale mutated object를 반환할 수 있다.

restore 중 IAVL `Set()` 또는 `Remove()`가 실패하면 `ErrFatalLedger`로 반환한다. 이 경우 ledger tree가 일부만 복구되었을 수 있으므로 일반 transaction error로 취급하지 않는다.

### MemLedger

`MemLedger`는 simulation/check path에서 immutable tree를 기반으로 동작하는 memory ledger다.

기존에는 `memStorage`에 있는 key 삭제만 revision에 기록했다. 이번 변경은 immutable tree에만 존재하는 committed item을 삭제할 때도 old value를 revision에 기록한다. 그래서 CheckTx/simulation 경로에서도 committed item deletion rollback이 같은 의미를 갖는다.

### StateLedger

`StateLedger`는 `exec` 값에 따라 실제 mutable ledger와 imitable/mem ledger에 snapshot/revert를 위임한다.

`exec=true`에서 만든 snapshot을 `exec=false` ledger에 revert하거나 그 반대의 경우는 ledger ID가 다르므로 `ErrInvalidSnapshot`으로 거부된다.

## Controller Snapshot Interface

controller layer에는 별도 interface가 추가되었다.

```go
type ITrxLedgerSnapshotter interface {
    Snapshot(exec bool) v1.Snapshot
    RevertToSnapshot(snap v1.Snapshot, exec bool) xerrors.XError
}
```

이 interface는 기존 handler interface에 embed하지 않는다. executor가 type assertion으로 snapshot 지원 여부를 확인한다. 따라서 snapshot을 지원하지 않는 mock/simulation handler는 자동으로 skip될 수 있다.

실제 controller 중 다음이 snapshotter를 구현한다.

- Account
- Gov
- Supply
- VPower

각 controller method는 내부 `v1.IStateLedger`에 위임한다.

## Executor Rollback Design

### Snapshot 대상

non-EVM transaction에서는 다음 controller를 모두 snapshot 대상으로 잡는다.

- `ctx.AcctHandler`
- `ctx.GovHandler`
- `ctx.SupplyHandler`
- `ctx.VPowerHandler`

tx type별 write-set을 정적으로 매핑하지 않는 이유는 누락 위험 때문이다. 현재 tx가 특정 controller를 주로 사용하더라도 내부에서 다른 controller handler를 호출할 수 있고, 향후 tx/precompile 확장도 같은 문제가 생길 수 있다.

전체 rollback 대상 controller를 snapshot하면 비용은 조금 늘지만, transaction rollback 의미가 tx type mapping 정확도에 의존하지 않는다.

### EVM Skip

`ctx.IsHandledByEVM()`이 true인 경우 executor-level snapshot은 생성하지 않는다.

대상:

- `TRX_CONTRACT`
- receiver account에 code가 있는 `TRX_TRANSFER`

이 경로는 기존 EVM controller의 `StateDBWrapper.Snapshot()` / `RevertToSnapshot()` 정책을 유지한다.

### Revert 순서

snapshot 생성 순서는 Account, Gov, Supply, VPower다. revert는 역순으로 실행한다.

```text
snapshot: Account -> Gov -> Supply -> VPower
revert:   VPower  -> Supply -> Gov -> Account
```

역순 revert는 일반적인 transactional resource rollback 순서와 맞다. 뒤에서 생성된 state dependency가 앞 controller state를 참조할 가능성을 줄인다.

## Cost Model

`R = len(revisions) - snap.revision`이라고 할 때, snapshot/revert 비용은 다음과 같다.

| Operation | IAVL read | IAVL mutation | Memory work | Complexity |
| --- | ---: | ---: | --- | --- |
| `Snapshot()` | 0 | 0 | lock + small struct copy | `O(1)` |
| `MutableLedger.Set()` | 1 `Get` | 1 `Set` | append revision if value changed | `O(log N)` IAVL op |
| `MutableLedger.Del()` | 0 | 1 `Remove` | append revision if key removed | `O(log N)` IAVL op |
| `MutableLedger.RevertToSnapshot()` | 0 | `R` `Set/Remove` | clear cache + truncate revisions | `O(R * log N)` |
| `MemLedger.Set()` | up to 1 immutable `Get` | 0 | map write + optional revision append | `O(1)` plus read |
| `MemLedger.Del()` | up to 1 immutable `Get` | 0 | map delete marker + optional revision append | `O(1)` plus read |
| `MemLedger.RevertToSnapshot()` | 0 | 0 | `R` map writes | `O(R)` |

Notes:

- non-EVM tx는 Account/Gov/Supply/VPower에 대해 최대 4개 snapshot을 만든다.
- `R`은 unique key 수가 아니라 revision 수다. 같은 key를 여러 번 바꾸면 그 횟수만큼 revert 비용이 늘어난다.
- failed non-EVM tx에서 MutableLedger 변경이 `R`개라면 IAVL mutation은 대략 실행 `R` + revert `R` = `2R`가 된다.
- 전체 rollback 비용은 `R_account + R_gov + R_supply + R_vpower`에 비례한다.

## Failure Policy

| 상황 | 처리 |
| --- | --- |
| ExecuteTrx success | 기존처럼 `postRunTrx()` 실행 |
| non-EVM ExecuteTrx error + rollback success + reload success + `ctx.Exec == true` | original execute error 반환, fee/nonce는 `postRunTrx()`로 반영 |
| non-EVM ExecuteTrx error + rollback success + reload success + `ctx.Exec == false` | original execute error 반환, `postRunTrx()` skip |
| rollback failure | panic |
| account reload failure | reload error를 original execute error로 wrap해서 반환, `postRunTrx()` skip |
| EVM-handled tx | executor-level rollback disabled |

rollback failure를 panic으로 처리하는 이유는 ledger restore 실패가 일반 transaction invalid와 다르기 때문이다. 일부 state만 복구된 fatal state일 수 있으므로 block execution을 계속 진행하지 않는다.

## Account Reload

rollback 이후 `ctx.Sender`, `ctx.Payer`, `ctx.Receiver`를 account ledger에서 다시 읽는다.

필요한 이유:

- rollback은 serialized ledger state를 복구한다.
- caller가 이미 들고 있던 Go object pointer 자체를 되돌리지는 않는다.
- `postRunTrx()`는 `ctx.Sender`/`ctx.Payer`를 직접 수정하고 저장한다.
- reload 없이 post-run을 수행하면 rollback 이전의 stale account pointer가 다시 ledger에 저장될 수 있다.

reload 규칙:

- sender: `ctx.Tx.From`으로 `FindAccount`
- payer: payer signature가 있으면 `VerifyPayerTrxRLP()`로 payer address를 다시 계산 후 `FindAccount`
- payer signature가 없으면 `ctx.Payer = ctx.Sender`
- receiver: `ctx.Tx.To == nil`이면 zero address, 이후 `FindOrNewAccount`

## Test Double Policy

실제 controller는 ledger snapshotter를 구현한다.

`ctrlers/mocks/acct.AcctHandlerMock`도 rollback regression test를 위해 `ITrxLedgerSnapshotter`를 구현한다. mock snapshot은 real ledger snapshot handle을 해석하지 않고, wallet/account clone stack으로 상태를 저장하고 복구한다.

이 mock 정책의 목적은 executor orchestration을 검증하는 것이다.

- snapshot 호출 여부
- revert 호출 여부
- rollback 후 stale account pointer가 재저장되지 않는지
- rollback failure 시 panic이 발생하는지
- EVM-handled tx에서 executor snapshot이 skip되는지

## Known Limits

이 rollback boundary는 `v1.IStateLedger` state를 대상으로 한다.

다음과 같은 controller in-memory field는 snapshot 대상이 아니다.

- `SupplyCtrler.lastTotalSupply`
- `VPowerCtrler.allDelegatees`
- `VPowerCtrler.lastValidators`
- `GovCtrler.newGovParams`

현재 transaction execution path에서 rollback 대상 state는 ledger에 집중되어 있다. 향후 `ExecuteTrx()`가 controller in-memory field를 직접 변경하는 경우에는 별도의 rollback 또는 reload 정책이 필요하다.

또한 ledger rollback은 serialized state를 복구하지만 이미 caller가 들고 있는 object pointer를 mutate해서 되돌리지 않는다. 이 때문에 executor-level account reload가 설계에 포함되어 있다.
