### PR TITLE
EVM BLOCKHASH Deterministic Provider

### DIFF
--- a/ctrlers/vm/evm/block_ctx.go
+++ b/ctrlers/vm/evm/block_ctx.go
@@ -1,13 +1,13 @@
 package evm
 
 import (
+	"math"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 	ethcore "github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/holiman/uint256"
-	tmrpccore "github.com/tendermint/tendermint/rpc/core"
 )
 
 var (
@@ -15,23 +15,33 @@ var (
 	gasTipCap = uint256.NewInt(0)
 )
 
-func GetHash(h uint64) common.Hash {
-	var blockHash common.Hash
-
-	height := int64(h)
-	retBlock, err := tmrpccore.Block(nil, &height)
-	if err != nil {
-		return blockHash // zero hash
-	}
-	blockHash.SetBytes(retBlock.BlockID.Hash)
-	return blockHash
+func zeroBlockHashProvider(uint64) common.Hash {
+	return common.Hash{}
 }
 
-func evmBlockContext(coinbase common.Address, gasLimit int64, bn int64, tm int64) vm.BlockContext {
+func newBlockHashProvider(currentHeight int64, lookup func(int64) (common.Hash, bool)) vm.GetHashFunc {
+	return func(height uint64) common.Hash {
+		if height > math.MaxInt64 || int64(height) >= currentHeight || lookup == nil {
+			return common.Hash{}
+		}
+
+		hash, ok := lookup(int64(height))
+		if !ok {
+			return common.Hash{}
+		}
+		return hash
+	}
+}
+
+func evmBlockContext(coinbase common.Address, gasLimit int64, bn int64, tm int64, getHash vm.GetHashFunc) vm.BlockContext {
+	if getHash == nil {
+		getHash = zeroBlockHashProvider
+	}
+
 	return vm.BlockContext{
 		CanTransfer: ethcore.CanTransfer,
 		Transfer:    ethcore.Transfer,
-		GetHash:     GetHash,
+		GetHash:     getHash,
 		Coinbase:    coinbase,
 		GasLimit:    uint64(gasLimit), // issue #44
 		BlockNumber: big.NewInt(bn),

--- a/ctrlers/vm/evm/blockhash_test.go
+++ b/ctrlers/vm/evm/blockhash_test.go
@@ -1,0 +1,137 @@
+package evm
+
+import (
+	"testing"
+	"time"
+
+	cfg "github.com/beatoz/beatoz-go/cmd/config"
+	ctrlertypes "github.com/beatoz/beatoz-go/ctrlers/types"
+	"github.com/beatoz/beatoz-go/types"
+	bytes2 "github.com/beatoz/beatoz-go/types/bytes"
+	"github.com/beatoz/beatoz-sdk-go/web3"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+	abcitypes "github.com/tendermint/tendermint/abci/types"
+	tmlog "github.com/tendermint/tendermint/libs/log"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+)
+
+func Test_Blockhash(t *testing.T) {
+	config := cfg.DefaultConfig()
+	config.SetChainId("0xDEA8D3")
+	config.SetRoot(t.TempDir())
+
+	acctHandler := newBlockhashTestAcctHandler()
+	ctrler := NewEVMCtrler(config, acctHandler, tmlog.NewNopLogger())
+	t.Cleanup(func() {
+		require.NoError(t, ctrler.Close())
+	})
+
+	block1Hash := common.HexToHash("0x1111111111111111111111111111111111111111111111111111111111111111")
+	block1Ctx := ctrlertypes.NewBlockContext(
+		abcitypes.RequestBeginBlock{
+			Hash: block1Hash.Bytes(),
+			Header: tmproto.Header{
+				ChainID: config.ChainIdHex(),
+				Height:  1,
+				Time:    time.Now(),
+			},
+		},
+		govMock, acctHandler, ctrler, nil, nil,
+	)
+
+	_, xerr := ctrler.BeginBlock(block1Ctx)
+	require.NoError(t, xerr)
+	_, _, xerr = ctrler.Commit()
+	require.NoError(t, xerr)
+
+	block2Ctx := ctrlertypes.NewBlockContext(
+		abcitypes.RequestBeginBlock{
+			Hash: common.HexToHash("0x2222222222222222222222222222222222222222222222222222222222222222").Bytes(),
+			Header: tmproto.Header{
+				ChainID: config.ChainIdHex(),
+				Height:  2,
+				Time:    time.Now(),
+				LastBlockId: tmproto.BlockID{
+					Hash: block1Hash.Bytes(),
+				},
+			},
+		},
+		govMock, acctHandler, ctrler, nil, nil,
+	)
+
+	_, xerr = ctrler.BeginBlock(block2Ctx)
+	require.NoError(t, xerr)
+
+	fromAcct := acctHandler.walletsArr[0].GetAccount()
+	contractAcct := ctrlertypes.NewAccount(types.RandAddress())
+	contractAcct.SetCode([]byte{1})
+	acctHandler.contAccts = append(acctHandler.contAccts, contractAcct)
+
+	// PUSH1 1; BLOCKHASH; PUSH1 0; MSTORE; PUSH1 32; PUSH1 0; RETURN.
+	blockhashRuntime := []byte{
+		0x60, 0x01,
+		0x40,
+		0x60, 0x00,
+		0x52,
+		0x60, 0x20,
+		0x60, 0x00,
+		0xf3,
+	}
+	ctrler.stateDBWrapper.SetCode(contractAcct.Address.Array20(), blockhashRuntime)
+
+	txctx := &ctrlertypes.TrxContext{
+		BlockContext: block2Ctx,
+		TxHash:       bytes2.RandBytes(32),
+		Tx: web3.NewTrxContract(
+			fromAcct.Address,
+			contractAcct.Address,
+			fromAcct.GetNonce(),
+			100_000,
+			govMock.GasPrice(),
+			uint256.NewInt(0),
+			nil,
+		),
+		TxIdx:    1,
+		Exec:     true,
+		Sender:   fromAcct,
+		Receiver: contractAcct,
+	}
+
+	require.NoError(t, ctrler.ValidateTrx(txctx))
+	require.NotPanics(t, func() {
+		xerr = ctrler.ExecuteTrx(txctx)
+	})
+	require.NoError(t, xerr)
+	require.Equal(t, block1Hash.Bytes(), txctx.RetData)
+}
+
+func Test_BlockhashProvider(t *testing.T) {
+	hash := common.HexToHash("0x3333333333333333333333333333333333333333333333333333333333333333")
+	provider := newBlockHashProvider(300, func(height int64) (common.Hash, bool) {
+		if height == 299 {
+			return hash, true
+		}
+		return common.Hash{}, false
+	})
+
+	require.Equal(t, hash, provider(299))
+	require.Equal(t, common.Hash{}, provider(300))
+	require.Equal(t, common.Hash{}, provider(301))
+	require.Equal(t, common.Hash{}, provider(298))
+}
+
+func newBlockhashTestAcctHandler() *acctHandlerMock {
+	handler := &acctHandlerMock{
+		origin:     true,
+		walletsMap: make(map[string]*web3.Wallet),
+	}
+	for i := 0; i < 2; i++ {
+		wallet := web3.NewWallet(nil)
+		wallet.GetAccount().AddBalance(uint256.MustFromDecimal("1000000000000000000000000000"))
+		handler.walletsMap[wallet.Address().String()] = wallet
+		handler.walletsArr = append(handler.walletsArr, wallet)
+	}
+	return handler
+}

--- a/ctrlers/vm/evm/ctrler.go
+++ b/ctrlers/vm/evm/ctrler.go
@@ -69,6 +69,10 @@ func blockKey(h int64) []byte {
 	return []byte(fmt.Sprintf("bn%v", h))
 }
 
+func blockHashKey(h int64) []byte {
+	return []byte(fmt.Sprintf("bh%v", h))
+}
+
 type EVMCtrler struct {
 	vmevm          *ethvm.EVM
 	ethChainConfig *params.ChainConfig
@@ -77,9 +81,10 @@ type EVMCtrler struct {
 	acctHandler    ctrlertypes.IAccountHandler
 	blockGasPool   *ethcore.GasPool
 
-	metadb          tmdb.DB
-	lastRootHash    bytes.HexBytes
-	lastBlockHeight int64
+	metadb           tmdb.DB
+	lastRootHash     bytes.HexBytes
+	lastBlockHeight  int64
+	currentBlockHash common.Hash
 
 	logger tmlog.Logger
 	mtx    sync.RWMutex
@@ -140,8 +145,15 @@ func (ctrler *EVMCtrler) BeginBlock(bctx *ctrlertypes.BlockContext) ([]abcitypes
 	ctrler.mtx.Lock()
 	defer ctrler.mtx.Unlock()
 
-	if ctrler.lastBlockHeight+1 != bctx.Height() {
-		return nil, xerrors.ErrBeginBlock.Wrapf("wrong block height - expected: %v, actual: %v", ctrler.lastBlockHeight+1, bctx.Height())
+	height := bctx.Height()
+	blockInfo := bctx.BlockInfo()
+	if ctrler.lastBlockHeight+1 != height {
+		return nil, xerrors.ErrBeginBlock.Wrapf("wrong block height - expected: %v, actual: %v", ctrler.lastBlockHeight+1, height)
+	}
+
+	prevBlockHash := common.BytesToHash(blockInfo.Header.LastBlockId.Hash)
+	if xerr := ctrler.syncPrevBlockHash(height, prevBlockHash); xerr != nil {
+		return nil, xerr
 	}
 
 	stdb, err := NewStateDBWrapper(ctrler.ethDB, ctrler.lastRootHash, bctx.AcctHandler, ctrler.logger)
@@ -149,8 +161,15 @@ func (ctrler *EVMCtrler) BeginBlock(bctx *ctrlertypes.BlockContext) ([]abcitypes
 		return nil, xerrors.From(err)
 	}
 
-	beneficiary := bytes.HexBytes(bctx.BlockInfo().Header.ProposerAddress).Array20()
-	blockContext := evmBlockContext(beneficiary, bctx.GetBlockGasLimit(), bctx.Height(), bctx.TimeSeconds())
+	beneficiary := bytes.HexBytes(blockInfo.Header.ProposerAddress).Array20()
+	ctrler.currentBlockHash = common.BytesToHash(blockInfo.Hash)
+	blockContext := evmBlockContext(
+		beneficiary,
+		bctx.GetBlockGasLimit(),
+		height,
+		bctx.TimeSeconds(),
+		ctrler.blockHashProvider(height),
+	)
 	ctrler.vmevm = ethvm.NewEVM(blockContext, ethvm.TxContext{
 		GasPrice: bctx.GovHandler.GasPrice().ToBig(),
 	}, stdb, ctrler.ethChainConfig, ethvm.Config{NoBaseFee: true})
@@ -158,6 +177,55 @@ func (ctrler *EVMCtrler) BeginBlock(bctx *ctrlertypes.BlockContext) ([]abcitypes
 	ctrler.blockGasPool = bctx.GetBlockGasPool()
 
 	return nil, nil
+}
+
+func (ctrler *EVMCtrler) syncPrevBlockHash(height int64, hash common.Hash) xerrors.XError {
+	if height <= 1 || hash == (common.Hash{}) {
+		return nil
+	}
+
+	prevHeight := height - 1
+	storedHash, ok, err := ctrler.lookupBlockHash(prevHeight)
+	if err != nil {
+		return xerrors.ErrBlockHashLookup.Wrap(err)
+	}
+	if ok {
+		if storedHash != hash {
+			return xerrors.ErrBeginBlock.Wrapf(
+				"previous block hash mismatch - height: %d, stored: %x, header: %x",
+				prevHeight,
+				storedHash.Bytes(),
+				hash.Bytes(),
+			)
+		}
+		return nil
+	}
+
+	if err := ctrler.metadb.SetSync(blockHashKey(prevHeight), hash.Bytes()); err != nil {
+		return xerrors.From(err)
+	}
+	return nil
+}
+
+func (ctrler *EVMCtrler) blockHashProvider(currentHeight int64) ethvm.GetHashFunc {
+	return newBlockHashProvider(currentHeight, func(height int64) (common.Hash, bool) {
+		hash, ok, err := ctrler.lookupBlockHash(height)
+		if err != nil {
+			return common.Hash{}, false
+		}
+		return hash, ok
+	})
+}
+
+func (ctrler *EVMCtrler) lookupBlockHash(height int64) (common.Hash, bool, error) {
+	bz, err := ctrler.metadb.Get(blockHashKey(height))
+	if err != nil {
+		return common.Hash{}, false, err
+	}
+	if len(bz) != common.HashLength {
+		return common.Hash{}, false, nil
+	}
+	return common.BytesToHash(bz), true, nil
 }
 
 func (ctrler *EVMCtrler) ValidateTrx(ctx *ctrlertypes.TrxContext) xerrors.XError {
@@ -418,6 +486,9 @@ func (ctrler *EVMCtrler) Commit() ([]byte, int64, xerrors.XError) {
 	batch := ctrler.metadb.NewBatch()
 	batch.Set(lastBlockHeightKey, []byte(strconv.FormatInt(ctrler.lastBlockHeight, 10)))
 	batch.Set(blockKey(ctrler.lastBlockHeight), ctrler.lastRootHash)
+	if ctrler.currentBlockHash != (common.Hash{}) {
+		batch.Set(blockHashKey(ctrler.lastBlockHeight), ctrler.currentBlockHash.Bytes())
+	}
 	batch.WriteSync()
 	batch.Close()
 

--- a/ctrlers/vm/evm/ctrler.go
+++ b/ctrlers/vm/evm/ctrler.go
@@ -484,13 +484,32 @@ func (ctrler *EVMCtrler) Commit() ([]byte, int64, xerrors.XError) {
 	ctrler.lastRootHash = rootHash[:]
 
 	batch := ctrler.metadb.NewBatch()
-	batch.Set(lastBlockHeightKey, []byte(strconv.FormatInt(ctrler.lastBlockHeight, 10)))
-	batch.Set(blockKey(ctrler.lastBlockHeight), ctrler.lastRootHash)
-	if ctrler.currentBlockHash != (common.Hash{}) {
-		batch.Set(blockHashKey(ctrler.lastBlockHeight), ctrler.currentBlockHash.Bytes())
+	closeBatch := func(cause error) xerrors.XError {
+		if err := batch.Close(); err != nil {
+			return xerrors.From(err)
+		}
+		if cause != nil {
+			return xerrors.From(cause)
+		}
+		return nil
 	}
-	batch.WriteSync()
-	batch.Close()
+	if err := batch.Set(lastBlockHeightKey, []byte(strconv.FormatInt(ctrler.lastBlockHeight, 10))); err != nil {
+		return nil, ctrler.lastBlockHeight, closeBatch(err)
+	}
+	if err := batch.Set(blockKey(ctrler.lastBlockHeight), ctrler.lastRootHash); err != nil {
+		return nil, ctrler.lastBlockHeight, closeBatch(err)
+	}
+	if ctrler.currentBlockHash != (common.Hash{}) {
+		if err := batch.Set(blockHashKey(ctrler.lastBlockHeight), ctrler.currentBlockHash.Bytes()); err != nil {
+			return nil, ctrler.lastBlockHeight, closeBatch(err)
+		}
+	}
+	if err := batch.WriteSync(); err != nil {
+		return nil, ctrler.lastBlockHeight, closeBatch(err)
+	}
+	if xerr := closeBatch(nil); xerr != nil {
+		return nil, ctrler.lastBlockHeight, xerr
+	}
 
 	stdb, err := NewStateDBWrapper(ctrler.ethDB, ctrler.lastRootHash, ctrler.acctHandler, ctrler.logger)
 	if err != nil {

--- a/ctrlers/vm/evm/ctrler.go
+++ b/ctrlers/vm/evm/ctrler.go
@@ -81,10 +81,10 @@ type EVMCtrler struct {
 	acctHandler    ctrlertypes.IAccountHandler
 	blockGasPool   *ethcore.GasPool
 
-	metadb           tmdb.DB
-	lastRootHash     bytes.HexBytes
-	lastBlockHeight  int64
-	currentBlockHash common.Hash
+	metadb          tmdb.DB
+	lastRootHash    bytes.HexBytes
+	lastBlockHash   common.Hash
+	lastBlockHeight int64
 
 	logger tmlog.Logger
 	mtx    sync.RWMutex
@@ -162,7 +162,7 @@ func (ctrler *EVMCtrler) BeginBlock(bctx *ctrlertypes.BlockContext) ([]abcitypes
 	}
 
 	beneficiary := bytes.HexBytes(blockInfo.Header.ProposerAddress).Array20()
-	ctrler.currentBlockHash = common.BytesToHash(blockInfo.Hash)
+	ctrler.lastBlockHash = common.BytesToHash(blockInfo.Hash)
 	blockContext := evmBlockContext(
 		beneficiary,
 		bctx.GetBlockGasLimit(),
@@ -499,8 +499,8 @@ func (ctrler *EVMCtrler) Commit() ([]byte, int64, xerrors.XError) {
 	if err := batch.Set(blockKey(ctrler.lastBlockHeight), ctrler.lastRootHash); err != nil {
 		return nil, ctrler.lastBlockHeight, closeBatch(err)
 	}
-	if ctrler.currentBlockHash != (common.Hash{}) {
-		if err := batch.Set(blockHashKey(ctrler.lastBlockHeight), ctrler.currentBlockHash.Bytes()); err != nil {
+	if ctrler.lastBlockHash != (common.Hash{}) {
+		if err := batch.Set(blockHashKey(ctrler.lastBlockHeight), ctrler.lastBlockHash.Bytes()); err != nil {
 			return nil, ctrler.lastBlockHeight, closeBatch(err)
 		}
 	}

--- a/ctrlers/vm/evm/query.go
+++ b/ctrlers/vm/evm/query.go
@@ -90,7 +90,7 @@ func (ctrler *EVMCtrler) callVM(from, to types.Address, data []byte, height, blo
 		SkipAccountChecks: true,
 	}
 
-	blockContext := evmBlockContext(sender, math.MaxInt64, height, blockTime)
+	blockContext := evmBlockContext(sender, math.MaxInt64, height, blockTime, ctrler.blockHashProvider(height))
 
 	txContext := core.NewEVMTxContext(vmmsg)
 	vmevm := vm.NewEVM(blockContext, txContext, state, ctrler.ethChainConfig, vm.Config{NoBaseFee: true})

--- a/types/xerrors/xerror.go
+++ b/types/xerrors/xerror.go
@@ -81,6 +81,7 @@ var (
 	ErrNotVotingPeriod       = NewOrdinary("not voting period")
 	ErrDuplicatedKey         = NewOrdinary("already existed key")
 	ErrInvalidWeight         = NewOrdinary("invalid weight")
+	ErrBlockHashLookup       = NewOrdinary("failed to lookup block hash")
 )
 
 type XError interface {


### PR DESCRIPTION
# Replace Tendermint RPC-Based BLOCKHASH with metaDB-Backed Deterministic Provider

## Summary

This PR replaces the Tendermint RPC-dependent `GetHash()` implementation with a deterministic block hash provider backed by the EVM controller's own metaDB.

Previously, the EVM `BLOCKHASH` opcode called `tmrpccore.Block()`, which accesses a process-local RPC environment initialized only when the RPC server is enabled. Validators running with `rpc.laddr=""` held a nil environment, causing a nil pointer panic during `EndBlock` whenever a contract executed `BLOCKHASH`. Even with RPC enabled, validators with different local BlockStore histories could return different hash values for the same height, making EVM execution non-deterministic across the network.

The fix stores each block's hash in metaDB at commit time using a `"bh{height}"` key and supplies it to the EVM via an injected `GetHashFunc`. The previous block hash is also written during `BeginBlock` from `Header.LastBlockId.Hash` and validated against any stored value, providing a consistency check and a recovery path after restart.

## Changes

- Remove `GetHash()` and its `tmrpccore.Block()` dependency from `block_ctx.go`.
- Add `newBlockHashProvider()` that returns a `vm.GetHashFunc` backed by a caller-supplied lookup closure, enforcing zero hash for the current block and future heights.
- Add `zeroBlockHashProvider()` as a safe fallback when no lookup is available.
- Change `evmBlockContext()` to accept an explicit `vm.GetHashFunc` parameter instead of hardcoding the removed `GetHash`.
- Add `blockHashKey(h int64)` to generate `"bh{height}"` metaDB keys distinct from the existing state root keys (`"bn{height}"`).
- Add `currentBlockHash` field to `EVMCtrler`; set it from `blockInfo.Hash` in `BeginBlock`.
- Add `syncPrevBlockHash()`: on each `BeginBlock`, write `Header.LastBlockId.Hash` to metaDB for `height-1` if not already present, and return an error if the stored value does not match.
- Add `lookupBlockHash()`: read and validate a stored hash from metaDB by `blockHashKey`.
- Add `blockHashProvider()`: construct the injected `GetHashFunc` using `lookupBlockHash` as the lookup closure.
- Write `currentBlockHash` to metaDB in `Commit()` as part of the existing metadata batch.
- Pass `ctrler.blockHashProvider(height)` to `evmBlockContext` in both `BeginBlock` and the query path `callVM`.
- Add `ErrBlockHashLookup` error type.
- Add `Test_Blockhash` to verify that the `BLOCKHASH` opcode returns the correct stored hash end-to-end.
- Add `Test_BlockhashProvider` to verify boundary conditions: current height, future height, and a stored past height.

## Changed Files

- `ctrlers/vm/evm/block_ctx.go`: removes RPC-based `GetHash`, adds `newBlockHashProvider` and `zeroBlockHashProvider`, adds `getHash` parameter to `evmBlockContext`.
- `ctrlers/vm/evm/ctrler.go`: adds `blockHashKey`, `currentBlockHash` field, `syncPrevBlockHash`, `lookupBlockHash`, `blockHashProvider`; updates `BeginBlock` and `Commit` to manage block hash storage.
- `ctrlers/vm/evm/query.go`: passes `blockHashProvider` to `evmBlockContext` in the query execution path.
- `ctrlers/vm/evm/blockhash_test.go`: new file with end-to-end and unit tests for the block hash provider.
- `types/xerrors/xerror.go`: adds `ErrBlockHashLookup`.

## Test

```bash
go test ./ctrlers/vm/evm -run '^Test_Blockhash' -count=1 -v
```

Result:

```text
=== RUN   Test_Blockhash
--- PASS: Test_Blockhash (0.XXs)
=== RUN   Test_BlockhashProvider
--- PASS: Test_BlockhashProvider (0.XXs)
ok  	github.com/beatoz/beatoz-go/ctrlers/vm/evm
```
