### PR TITLE
feat: add ledger-v2

### DIFF
--- a/ctrlers/account/ctrler.go
+++ b/ctrlers/account/ctrler.go
@@ -6,7 +6,7 @@ import (
 	cfg "github.com/beatoz/beatoz-go/cmd/config"
 	btztypes "github.com/beatoz/beatoz-go/ctrlers/types"
 	"github.com/beatoz/beatoz-go/genesis"
-	v1 "github.com/beatoz/beatoz-go/ledger/v1"
+	v2 "github.com/beatoz/beatoz-go/ledger/v2"
 	"github.com/beatoz/beatoz-go/types"
 	"github.com/beatoz/beatoz-go/types/xerrors"
 	"github.com/holiman/uint256"
@@ -15,7 +15,7 @@ import (
 )
 
 type AcctCtrler struct {
-	acctState v1.IStateLedger
+	acctState v2.IStateLedger
 
 	newbiesCheck   map[btztypes.AcctKey]*btztypes.Account
 	newbiesDeliver map[btztypes.AcctKey]*btztypes.Account
@@ -27,7 +27,7 @@ type AcctCtrler struct {
 func NewAcctCtrler(config *cfg.Config, logger tmlog.Logger) (*AcctCtrler, error) {
 	lg := logger.With("module", "beatoz_AcctCtrler")
 
-	if _state, xerr := v1.NewStateLedger("accounts", config.DBDir(), 10000, func(key v1.LedgerKey) v1.ILedgerItem { return &btztypes.Account{} }, lg); xerr != nil {
+	if _state, xerr := v2.NewStateLedger("accounts", config.DBDir(), 10000, func(key v2.LedgerKey) v2.ILedgerItem { return &btztypes.Account{} }, lg); xerr != nil {
 		return nil, xerr
 	} else {
 		return &AcctCtrler{
@@ -37,6 +37,23 @@ func NewAcctCtrler(config *cfg.Config, logger tmlog.Logger) (*AcctCtrler, error)
 			logger:         lg,
 		}, nil
 	}
+}
+
+func (ctrler *AcctCtrler) CacheContext(exec bool) (*AcctCtrler, func() xerrors.XError) {
+	ctrler.mtx.RLock()
+	defer ctrler.mtx.RUnlock()
+
+	cachedState, writeCache := ctrler.acctState.CacheContext(exec)
+	return &AcctCtrler{
+		acctState:      cachedState,
+		newbiesCheck:   clonePendingAccounts(ctrler.newbiesCheck),
+		newbiesDeliver: clonePendingAccounts(ctrler.newbiesDeliver),
+		logger:         ctrler.logger,
+	}, writeCache
+}
+
+func (ctrler *AcctCtrler) CacheHandlerContext(exec bool) (btztypes.IAccountHandler, func() xerrors.XError) {
+	return ctrler.CacheContext(exec)
 }
 
 func (ctrler *AcctCtrler) InitLedger(req interface{}) xerrors.XError {
@@ -146,7 +163,7 @@ func (ctrler *AcctCtrler) FindAccount(addr types.Address, exec bool) *btztypes.A
 }
 
 func (ctrler *AcctCtrler) findAccount(addr types.Address, exec bool) *btztypes.Account {
-	if acct, xerr := ctrler.acctState.Get(v1.LedgerKeyAccount(addr), exec); xerr != nil {
+	if acct, xerr := ctrler.acctState.Get(v2.LedgerKeyAccount(addr), exec); xerr != nil {
 		return nil
 	} else {
 		return acct.(*btztypes.Account)
@@ -308,7 +325,18 @@ func (ctrler *AcctCtrler) SetAccount(acct *btztypes.Account, exec bool) xerrors.
 }
 
 func (ctrler *AcctCtrler) setAccount(acct *btztypes.Account, exec bool) xerrors.XError {
-	return ctrler.acctState.Set(v1.LedgerKeyAccount(acct.Address), acct, exec)
+	return ctrler.acctState.Set(v2.LedgerKeyAccount(acct.Address), acct, exec)
+}
+
+func clonePendingAccounts(src map[btztypes.AcctKey]*btztypes.Account) map[btztypes.AcctKey]*btztypes.Account {
+	dst := make(map[btztypes.AcctKey]*btztypes.Account, len(src))
+	for key, acct := range src {
+		cloned := acct.Clone()
+		cloned.SetDocURL(acct.GetDocURL())
+		cloned.SetCode(append([]byte(nil), acct.GetCode()...))
+		dst[key] = cloned
+	}
+	return dst
 }
 
 func (ctrler *AcctCtrler) SimuAcctCtrlerAt(height int64) (btztypes.IAccountHandler, xerrors.XError) {
@@ -330,14 +358,14 @@ var _ btztypes.IBlockHandler = (*AcctCtrler)(nil)
 var _ btztypes.IAccountHandler = (*AcctCtrler)(nil)
 
 type SimuAcctCtrler struct {
-	simuLedger v1.IImitable
+	simuLedger v2.IImitable
 	newbies    map[btztypes.AcctKey]*btztypes.Account
 	logger     tmlog.Logger
 	mtx        sync.RWMutex
 }
 
 func (memCtrler *SimuAcctCtrler) SetAccount(acct *btztypes.Account, exec bool) xerrors.XError {
-	return memCtrler.simuLedger.Set(v1.LedgerKeyAccount(acct.Address), acct)
+	return memCtrler.simuLedger.Set(v2.LedgerKeyAccount(acct.Address), acct)
 }
 
 func (memCtrler *SimuAcctCtrler) FindOrNewAccount(addr types.Address, exec bool) *btztypes.Account {
@@ -365,7 +393,7 @@ func (memCtrler *SimuAcctCtrler) FindAccount(addr types.Address, exec bool) *btz
 }
 
 func (memCtrler *SimuAcctCtrler) findAccount(addr types.Address) *btztypes.Account {
-	if acct, xerr := memCtrler.simuLedger.Get(v1.LedgerKeyAccount(addr)); xerr != nil {
+	if acct, xerr := memCtrler.simuLedger.Get(v2.LedgerKeyAccount(addr)); xerr != nil {
 		return nil
 	} else {
 		return acct.(*btztypes.Account)

--- a/ctrlers/account/query.go
+++ b/ctrlers/account/query.go
@@ -2,7 +2,7 @@ package account
 
 import (
 	ctrlertypes "github.com/beatoz/beatoz-go/ctrlers/types"
-	v1 "github.com/beatoz/beatoz-go/ledger/v1"
+	v2 "github.com/beatoz/beatoz-go/ledger/v2"
 	"github.com/beatoz/beatoz-go/libs/jsonx"
 	"github.com/beatoz/beatoz-go/types"
 	"github.com/beatoz/beatoz-go/types/bytes"
@@ -16,7 +16,7 @@ func (ctrler *AcctCtrler) Query(req abcitypes.RequestQuery, opts ...ctrlertypes.
 		return nil, xerrors.ErrQuery.Wrap(xerr)
 	}
 
-	item, xerr := immuLedger.Get(v1.LedgerKeyAccount(req.Data))
+	item, xerr := immuLedger.Get(v2.LedgerKeyAccount(req.Data))
 	if xerr != nil {
 		item = ctrlertypes.NewAccount(req.Data)
 	}

--- a/ctrlers/cache_context.go
+++ b/ctrlers/cache_context.go
@@ -1,0 +1,127 @@
+package ctrlers
+
+import (
+	ctrlertypes "github.com/beatoz/beatoz-go/ctrlers/types"
+	"github.com/beatoz/beatoz-go/types/xerrors"
+)
+
+type BlockCacheContext struct {
+	origGov    ctrlertypes.IGovHandler
+	origAcct   ctrlertypes.IAccountHandler
+	origSupply ctrlertypes.ISupplyHandler
+	origVPower ctrlertypes.IVPowerHandler
+
+	writeCaches []func() xerrors.XError
+	restored    bool
+}
+
+func NewBlockCacheContext(bctx *ctrlertypes.BlockContext, exec bool) *BlockCacheContext {
+	cachedAcct, writeAcct, ok := cacheAccountHandler(bctx.AcctHandler, exec)
+	if !ok {
+		return nil
+	}
+	cachedGov, writeGov, ok := cacheGovHandler(bctx.GovHandler, exec)
+	if !ok {
+		return nil
+	}
+	cachedSupply, writeSupply, ok := cacheSupplyHandler(bctx.SupplyHandler, exec)
+	if !ok {
+		return nil
+	}
+	cachedVPower, writeVPower, ok := cacheVPowerHandler(bctx.VPowerHandler, exec)
+	if !ok {
+		return nil
+	}
+
+	scope := &BlockCacheContext{
+		origGov:    bctx.GovHandler,
+		origAcct:   bctx.AcctHandler,
+		origSupply: bctx.SupplyHandler,
+		origVPower: bctx.VPowerHandler,
+		writeCaches: []func() xerrors.XError{
+			writeAcct,
+			writeGov,
+			writeSupply,
+			writeVPower,
+		},
+	}
+
+	bctx.GovHandler = cachedGov
+	bctx.AcctHandler = cachedAcct
+	bctx.SupplyHandler = cachedSupply
+	bctx.VPowerHandler = cachedVPower
+
+	return scope
+}
+
+func cacheAccountHandler(handler ctrlertypes.IAccountHandler, exec bool) (ctrlertypes.IAccountHandler, func() xerrors.XError, bool) {
+	if handler == nil {
+		return nil, noopWriteCache, true
+	}
+	cacheable, ok := handler.(ctrlertypes.ICacheableAccountHandler)
+	if !ok {
+		return nil, nil, false
+	}
+	cached, writeCache := cacheable.CacheHandlerContext(exec)
+	return cached, writeCache, true
+}
+
+func cacheGovHandler(handler ctrlertypes.IGovHandler, exec bool) (ctrlertypes.IGovHandler, func() xerrors.XError, bool) {
+	if handler == nil {
+		return nil, noopWriteCache, true
+	}
+	cacheable, ok := handler.(ctrlertypes.ICacheableGovHandler)
+	if !ok {
+		return nil, nil, false
+	}
+	cached, writeCache := cacheable.CacheHandlerContext(exec)
+	return cached, writeCache, true
+}
+
+func cacheSupplyHandler(handler ctrlertypes.ISupplyHandler, exec bool) (ctrlertypes.ISupplyHandler, func() xerrors.XError, bool) {
+	if handler == nil {
+		return nil, noopWriteCache, true
+	}
+	cacheable, ok := handler.(ctrlertypes.ICacheableSupplyHandler)
+	if !ok {
+		return nil, nil, false
+	}
+	cached, writeCache := cacheable.CacheHandlerContext(exec)
+	return cached, writeCache, true
+}
+
+func cacheVPowerHandler(handler ctrlertypes.IVPowerHandler, exec bool) (ctrlertypes.IVPowerHandler, func() xerrors.XError, bool) {
+	if handler == nil {
+		return nil, noopWriteCache, true
+	}
+	cacheable, ok := handler.(ctrlertypes.ICacheableVPowerHandler)
+	if !ok {
+		return nil, nil, false
+	}
+	cached, writeCache := cacheable.CacheHandlerContext(exec)
+	return cached, writeCache, true
+}
+
+func noopWriteCache() xerrors.XError {
+	return nil
+}
+
+func (scope *BlockCacheContext) Restore(bctx *ctrlertypes.BlockContext) {
+	if scope.restored {
+		return
+	}
+	bctx.GovHandler = scope.origGov
+	bctx.AcctHandler = scope.origAcct
+	bctx.SupplyHandler = scope.origSupply
+	bctx.VPowerHandler = scope.origVPower
+	scope.restored = true
+}
+
+func (scope *BlockCacheContext) Write() xerrors.XError {
+	for _, writeCache := range scope.writeCaches {
+		if xerr := writeCache(); xerr != nil {
+			return xerr
+		}
+	}
+	return nil
+}

--- a/ctrlers/gov/0_ctrler_test.go
+++ b/ctrlers/gov/0_ctrler_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/beatoz/beatoz-go/types"
 	"github.com/beatoz/beatoz-sdk-go/web3"
 	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
 	tmlog "github.com/tendermint/tendermint/libs/log"
 )
 
@@ -73,4 +74,14 @@ func TestMain(m *testing.M) {
 func signTrx(tx *ctrlertypes.Trx, signerAddr types.Address, chainId string) error {
 	_, _, err := acctMock.FindWallet(signerAddr).SignTrxRLP(tx, chainId)
 	return err
+}
+
+func TestDefaultNewItemGuards(t *testing.T) {
+	for _, key := range [][]byte{nil, []byte{0xff}} {
+		require.NotPanics(t, func() {
+			item := defaultNewItemFor(key)
+			require.NotNil(t, item)
+			require.Error(t, item.Decode(key, nil))
+		})
+	}
 }

--- a/ctrlers/gov/2_voting_test.go
+++ b/ctrlers/gov/2_voting_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/beatoz/beatoz-go/ctrlers/gov/proposal"
 	ctrlertypes "github.com/beatoz/beatoz-go/ctrlers/types"
-	v1 "github.com/beatoz/beatoz-go/ledger/v1"
+	v2 "github.com/beatoz/beatoz-go/ledger/v2"
 	"github.com/beatoz/beatoz-go/libs/jsonx"
 	"github.com/beatoz/beatoz-go/types"
 	"github.com/beatoz/beatoz-go/types/bytes"
@@ -212,7 +212,7 @@ func TestFreezingProposal(t *testing.T) {
 	// the proposal is frozen.
 	_, xerr = govCtrler.ReadProposal(trxCtxProposal.TxHash, false)
 	require.Equal(t, xerrors.ErrNotFoundProposal, xerr)
-	item, xerr := govCtrler.govState.Get(v1.LedgerKeyFrozenProp(trxCtxProposal.TxHash), false)
+	item, xerr := govCtrler.govState.Get(v2.LedgerKeyFrozenProp(trxCtxProposal.TxHash), false)
 	require.NoError(t, xerr)
 	frozenProp, _ := item.(*proposal.GovProposal)
 	require.NotNil(t, frozenProp.MajorOption())
@@ -258,7 +258,7 @@ func TestApplyingProposal(t *testing.T) {
 	require.NoError(t, xerr)
 	_, _, xerr = govCtrler.Commit()
 	require.NoError(t, xerr)
-	frozenProp, xerr := govCtrler.govState.Get(v1.LedgerKeyFrozenProp(trxCtxProposal.TxHash), false)
+	frozenProp, xerr := govCtrler.govState.Get(v2.LedgerKeyFrozenProp(trxCtxProposal.TxHash), false)
 	require.NoError(t, xerr)
 	require.NotNil(t, frozenProp)
 
@@ -273,7 +273,7 @@ func TestApplyingProposal(t *testing.T) {
 
 	_, _, xerr = govCtrler.Commit()
 	require.NoError(t, xerr)
-	frozenProp, xerr = govCtrler.govState.Get(v1.LedgerKeyFrozenProp(trxCtxProposal.TxHash), false)
+	frozenProp, xerr = govCtrler.govState.Get(v2.LedgerKeyFrozenProp(trxCtxProposal.TxHash), false)
 	require.Equal(t, xerrors.ErrNotFoundResult, xerr)
 	require.Nil(t, frozenProp)
 
@@ -298,7 +298,7 @@ func TestApplyInvalidGovParamsProposalRejected(t *testing.T) {
 	prop.AddOption(bzOpt)
 	require.NotNil(t, prop.UpdateMajorOption())
 
-	frozenKey := v1.LedgerKeyFrozenProp(txHash)
+	frozenKey := v2.LedgerKeyFrozenProp(txHash)
 	require.NoError(t, govCtrler.govState.Set(frozenKey, prop, true))
 
 	bctx := &ctrlertypes.BlockContext{}

--- a/ctrlers/gov/ctrler.go
+++ b/ctrlers/gov/ctrler.go
@@ -3,50 +3,50 @@ package gov
 import (
 	"bytes"
 	"errors"
+	"sync"
+
 	cfg "github.com/beatoz/beatoz-go/cmd/config"
 	"github.com/beatoz/beatoz-go/ctrlers/gov/proposal"
 	ctrlertypes "github.com/beatoz/beatoz-go/ctrlers/types"
 	"github.com/beatoz/beatoz-go/genesis"
-	v1 "github.com/beatoz/beatoz-go/ledger/v1"
+	v2 "github.com/beatoz/beatoz-go/ledger/v2"
 	"github.com/beatoz/beatoz-go/libs/jsonx"
 	"github.com/beatoz/beatoz-go/types"
 	abytes "github.com/beatoz/beatoz-go/types/bytes"
 	"github.com/beatoz/beatoz-go/types/xerrors"
 	"github.com/holiman/uint256"
 	"github.com/tendermint/tendermint/libs/log"
-	"sync"
 )
 
 type GovCtrler struct {
 	ctrlertypes.GovParams
 	newGovParams *ctrlertypes.GovParams
 
-	govState v1.IStateLedger
+	govState v2.IStateLedger
 
 	logger log.Logger
 	mtx    sync.RWMutex
 }
 
-var defaultNewItemFor = func(key v1.LedgerKey) v1.ILedgerItem {
-	if bytes.HasPrefix(key, v1.KeyPrefixGovParams) {
+var defaultNewItemFor = func(key v2.LedgerKey) v2.ILedgerItem {
+	if bytes.HasPrefix(key, v2.KeyPrefixGovParams) {
 		return &ctrlertypes.GovParams{}
 	}
-	if bytes.HasPrefix(key, v1.KeyPrefixProposal) || bytes.HasPrefix(key, v1.KeyPrefixFrozenProp) {
+	if bytes.HasPrefix(key, v2.KeyPrefixProposal) || bytes.HasPrefix(key, v2.KeyPrefixFrozenProp) {
 		return &proposal.GovProposal{}
 	}
-	panic("unknown key prefix")
-	return nil
+	return v2.NewInvalidLedgerItem("unknown gov ledger key prefix: 0x%x", []byte(key))
 }
 
 func NewGovCtrler(config *cfg.Config, logger log.Logger) (*GovCtrler, error) {
 	lg := logger.With("module", "beatoz_GovCtrler")
 
-	govState, xerr := v1.NewStateLedger("gov", config.DBDir(), 16, defaultNewItemFor, lg)
+	govState, xerr := v2.NewStateLedger("gov", config.DBDir(), 16, defaultNewItemFor, lg)
 	if xerr != nil {
 		return nil, xerr
 	}
 
-	params, xerr := govState.Get(v1.LedgerKeyGovParams(), true)
+	params, xerr := govState.Get(v2.LedgerKeyGovParams(), true)
 	// `params` may be nil
 	if xerr != nil && xerr != xerrors.ErrNotFoundResult {
 		return nil, xerr
@@ -61,6 +61,23 @@ func NewGovCtrler(config *cfg.Config, logger log.Logger) (*GovCtrler, error) {
 	}, nil
 }
 
+func (ctrler *GovCtrler) CacheContext(exec bool) (*GovCtrler, func() xerrors.XError) {
+	ctrler.mtx.RLock()
+	defer ctrler.mtx.RUnlock()
+
+	cachedState, writeCache := ctrler.govState.CacheContext(exec)
+	return &GovCtrler{
+		GovParams:    ctrler.GovParams,
+		newGovParams: ctrler.newGovParams,
+		govState:     cachedState,
+		logger:       ctrler.logger,
+	}, writeCache
+}
+
+func (ctrler *GovCtrler) CacheHandlerContext(exec bool) (ctrlertypes.IGovHandler, func() xerrors.XError) {
+	return ctrler.CacheContext(exec)
+}
+
 func (ctrler *GovCtrler) InitLedger(req interface{}) xerrors.XError {
 	ctrler.mtx.Lock()
 	defer ctrler.mtx.Unlock()
@@ -70,7 +87,7 @@ func (ctrler *GovCtrler) InitLedger(req interface{}) xerrors.XError {
 		return xerrors.ErrInitChain.Wrapf("wrong parameter: GovCtrler::InitLedger requires *genesis.GenesisAppState")
 	}
 	ctrler.GovParams = *genAppState.GovParams
-	_ = ctrler.govState.Set(v1.LedgerKeyGovParams(), &ctrler.GovParams, true)
+	_ = ctrler.govState.Set(v2.LedgerKeyGovParams(), &ctrler.GovParams, true)
 	return nil
 }
 
@@ -105,7 +122,7 @@ func (ctrler *GovCtrler) ValidateTrx(ctx *ctrlertypes.TrxContext) xerrors.XError
 		}
 
 		// check already exist
-		prop, xerr := ctrler.govState.Get(v1.LedgerKeyProposal(ctx.TxHash), ctx.Exec)
+		prop, xerr := ctrler.govState.Get(v2.LedgerKeyProposal(ctx.TxHash), ctx.Exec)
 		if xerr != nil && xerr != xerrors.ErrNotFoundResult {
 			return xerr
 		} else if prop != nil {
@@ -170,7 +187,7 @@ func (ctrler *GovCtrler) ValidateTrx(ctx *ctrlertypes.TrxContext) xerrors.XError
 		}
 
 		// check already exist
-		item, xerr := ctrler.govState.Get(v1.LedgerKeyProposal(txpayload.TxHash), ctx.Exec)
+		item, xerr := ctrler.govState.Get(v2.LedgerKeyProposal(txpayload.TxHash), ctx.Exec)
 		if xerr != nil {
 			return xerr
 		}
@@ -233,7 +250,7 @@ func (ctrler *GovCtrler) execProposing(ctx *ctrlertypes.TrxContext) xerrors.XErr
 	for _, opt := range txpayload.Options {
 		prop.AddOption(opt)
 	}
-	if xerr := ctrler.govState.Set(v1.LedgerKeyProposal(prop.Header().TxHash), prop, ctx.Exec); xerr != nil {
+	if xerr := ctrler.govState.Set(v2.LedgerKeyProposal(prop.Header().TxHash), prop, ctx.Exec); xerr != nil {
 		return xerr
 	}
 
@@ -242,7 +259,7 @@ func (ctrler *GovCtrler) execProposing(ctx *ctrlertypes.TrxContext) xerrors.XErr
 
 func (ctrler *GovCtrler) execVoting(ctx *ctrlertypes.TrxContext) xerrors.XError {
 	txpayload, _ := ctx.Tx.Payload.(*ctrlertypes.TrxPayloadVoting)
-	item, xerr := ctrler.govState.Get(v1.LedgerKeyProposal(txpayload.TxHash), ctx.Exec)
+	item, xerr := ctrler.govState.Get(v2.LedgerKeyProposal(txpayload.TxHash), ctx.Exec)
 	if xerr != nil {
 		return xerr
 	}
@@ -250,7 +267,7 @@ func (ctrler *GovCtrler) execVoting(ctx *ctrlertypes.TrxContext) xerrors.XError 
 	if xerr = prop.DoVote(ctx.Tx.From, txpayload.Choice); xerr != nil {
 		return xerr
 	}
-	if xerr = ctrler.govState.Set(v1.LedgerKeyProposal(prop.Header().TxHash), prop, ctx.Exec); xerr != nil {
+	if xerr = ctrler.govState.Set(v2.LedgerKeyProposal(prop.Header().TxHash), prop, ctx.Exec); xerr != nil {
 		return xerr
 	}
 	if prop.MajorOption() != nil {
@@ -260,15 +277,15 @@ func (ctrler *GovCtrler) execVoting(ctx *ctrlertypes.TrxContext) xerrors.XError 
 }
 
 // freezeProposals is called from EndBlock
-func (ctrler *GovCtrler) freezeProposals(height int64) ([]v1.LedgerKey, []v1.LedgerKey, xerrors.XError) {
-	var frozenProps []v1.LedgerKey
-	var removedProps []v1.LedgerKey
+func (ctrler *GovCtrler) freezeProposals(height int64) ([]v2.LedgerKey, []v2.LedgerKey, xerrors.XError) {
+	var frozenProps []v2.LedgerKey
+	var removedProps []v2.LedgerKey
 	var newFrozens []*proposal.GovProposal
 
 	defer func() {
 		for _, _prop := range newFrozens {
-			// set new frozen proposal with v1.LedgerKeyFrozenProp
-			_ = ctrler.govState.Set(v1.LedgerKeyFrozenProp(_prop.Header().TxHash), _prop, true)
+			// set new frozen proposal with v2.LedgerKeyFrozenProp
+			_ = ctrler.govState.Set(v2.LedgerKeyFrozenProp(_prop.Header().TxHash), _prop, true)
 		}
 		for _, k := range frozenProps {
 			// remove frozen proposal
@@ -280,7 +297,7 @@ func (ctrler *GovCtrler) freezeProposals(height int64) ([]v1.LedgerKey, []v1.Led
 		}
 	}()
 
-	xerr := ctrler.govState.Seek(v1.KeyPrefixProposal, true, func(key v1.LedgerKey, item v1.ILedgerItem) xerrors.XError {
+	xerr := ctrler.govState.Seek(v2.KeyPrefixProposal, true, func(key v2.LedgerKey, item v2.ILedgerItem) xerrors.XError {
 		prop, _ := item.(*proposal.GovProposal)
 		if prop.Header().EndVotingHeight < height {
 
@@ -303,13 +320,13 @@ func (ctrler *GovCtrler) freezeProposals(height int64) ([]v1.LedgerKey, []v1.Led
 }
 
 // applyProposals is called from EndBlock
-func (ctrler *GovCtrler) applyProposals(height int64) ([]v1.LedgerKey, []v1.LedgerKey, xerrors.XError) {
-	var applied []v1.LedgerKey
-	var rejected []v1.LedgerKey
+func (ctrler *GovCtrler) applyProposals(height int64) ([]v2.LedgerKey, []v2.LedgerKey, xerrors.XError) {
+	var applied []v2.LedgerKey
+	var rejected []v2.LedgerKey
 
 	defer func() {
 		if ctrler.newGovParams != nil {
-			_ = ctrler.govState.Set(v1.LedgerKeyGovParams(), ctrler.newGovParams, true)
+			_ = ctrler.govState.Set(v2.LedgerKeyGovParams(), ctrler.newGovParams, true)
 		}
 
 		for _, k := range applied {
@@ -322,7 +339,7 @@ func (ctrler *GovCtrler) applyProposals(height int64) ([]v1.LedgerKey, []v1.Ledg
 		}
 	}()
 
-	xerr := ctrler.govState.Seek(v1.KeyPrefixFrozenProp, true, func(key v1.LedgerKey, item v1.ILedgerItem) xerrors.XError {
+	xerr := ctrler.govState.Seek(v2.KeyPrefixFrozenProp, true, func(key v2.LedgerKey, item v2.ILedgerItem) xerrors.XError {
 		prop, _ := item.(*proposal.GovProposal)
 		if prop.Header().ApplyHeight <= height {
 
@@ -385,7 +402,7 @@ func (ctrler *GovCtrler) ReadAllProposals(exec bool) ([]*proposal.GovProposal, x
 
 	var proposals []*proposal.GovProposal
 
-	if xerr := ctrler.govState.Seek(v1.KeyPrefixProposal, true, func(key v1.LedgerKey, item v1.ILedgerItem) xerrors.XError {
+	if xerr := ctrler.govState.Seek(v2.KeyPrefixProposal, true, func(key v2.LedgerKey, item v2.ILedgerItem) xerrors.XError {
 		prop, _ := item.(*proposal.GovProposal)
 		proposals = append(proposals, prop)
 		return nil
@@ -403,7 +420,7 @@ func (ctrler *GovCtrler) ReadProposal(txhash abytes.HexBytes, exec bool) (*propo
 	ctrler.mtx.RLock()
 	defer ctrler.mtx.RUnlock()
 
-	item, xerr := ctrler.govState.Get(v1.LedgerKeyProposal(txhash), exec)
+	item, xerr := ctrler.govState.Get(v2.LedgerKeyProposal(txhash), exec)
 	if xerr != nil {
 		if xerr.Contains(xerrors.ErrNotFoundResult) {
 			return nil, xerrors.ErrNotFoundProposal

--- a/ctrlers/gov/ctrler_block.go
+++ b/ctrlers/gov/ctrler_block.go
@@ -3,7 +3,7 @@ package gov
 import (
 	"encoding/hex"
 	"github.com/beatoz/beatoz-go/ctrlers/types"
-	"github.com/beatoz/beatoz-go/ledger/v1"
+	"github.com/beatoz/beatoz-go/ledger/v2"
 	types3 "github.com/beatoz/beatoz-go/types"
 	"github.com/beatoz/beatoz-go/types/xerrors"
 	types2 "github.com/tendermint/tendermint/abci/types"
@@ -58,7 +58,7 @@ func (ctrler *GovCtrler) EndBlock(ctx *types.BlockContext) ([]types2.Event, xerr
 		evts = append(evts, types2.Event{
 			Type: "proposal",
 			Attributes: []types2.EventAttribute{
-				{Key: []byte("frozen"), Value: []byte(hex.EncodeToString(v1.UnwrapKeyPrefix(k))), Index: true},
+				{Key: []byte("frozen"), Value: []byte(hex.EncodeToString(v2.UnwrapKeyPrefix(k))), Index: true},
 			},
 		})
 	}
@@ -66,7 +66,7 @@ func (ctrler *GovCtrler) EndBlock(ctx *types.BlockContext) ([]types2.Event, xerr
 		evts = append(evts, types2.Event{
 			Type: "proposal",
 			Attributes: []types2.EventAttribute{
-				{Key: []byte("removed"), Value: []byte(hex.EncodeToString(v1.UnwrapKeyPrefix(k))), Index: true},
+				{Key: []byte("removed"), Value: []byte(hex.EncodeToString(v2.UnwrapKeyPrefix(k))), Index: true},
 			},
 		})
 	}
@@ -74,7 +74,7 @@ func (ctrler *GovCtrler) EndBlock(ctx *types.BlockContext) ([]types2.Event, xerr
 		evts = append(evts, types2.Event{
 			Type: "proposal",
 			Attributes: []types2.EventAttribute{
-				{Key: []byte("applied"), Value: []byte(hex.EncodeToString(v1.UnwrapKeyPrefix(k))), Index: true},
+				{Key: []byte("applied"), Value: []byte(hex.EncodeToString(v2.UnwrapKeyPrefix(k))), Index: true},
 			},
 		})
 	}
@@ -82,7 +82,7 @@ func (ctrler *GovCtrler) EndBlock(ctx *types.BlockContext) ([]types2.Event, xerr
 		evts = append(evts, types2.Event{
 			Type: "proposal",
 			Attributes: []types2.EventAttribute{
-				{Key: []byte("rejected"), Value: []byte(hex.EncodeToString(v1.UnwrapKeyPrefix(k))), Index: true},
+				{Key: []byte("rejected"), Value: []byte(hex.EncodeToString(v2.UnwrapKeyPrefix(k))), Index: true},
 			},
 		})
 	}

--- a/ctrlers/gov/ctrler_punish.go
+++ b/ctrlers/gov/ctrler_punish.go
@@ -2,7 +2,7 @@ package gov
 
 import (
 	"github.com/beatoz/beatoz-go/ctrlers/gov/proposal"
-	v1 "github.com/beatoz/beatoz-go/ledger/v1"
+	v2 "github.com/beatoz/beatoz-go/ledger/v2"
 	"github.com/beatoz/beatoz-go/types"
 	"github.com/beatoz/beatoz-go/types/xerrors"
 )
@@ -14,12 +14,12 @@ func (ctrler *GovCtrler) doSlash(targetAddr types.Address) (int64, xerrors.XErro
 	var updatedProp []*proposal.GovProposal
 	defer func() {
 		for _, prop := range updatedProp {
-			_ = ctrler.govState.Set(v1.LedgerKeyProposal(prop.Header().TxHash), prop, true)
+			_ = ctrler.govState.Set(v2.LedgerKeyProposal(prop.Header().TxHash), prop, true)
 		}
 	}()
 
 	slashPower := int64(0)
-	_ = ctrler.govState.Seek(v1.KeyPrefixProposal, true, func(key v1.LedgerKey, item v1.ILedgerItem) xerrors.XError {
+	_ = ctrler.govState.Seek(v2.KeyPrefixProposal, true, func(key v2.LedgerKey, item v2.ILedgerItem) xerrors.XError {
 		prop, _ := item.(*proposal.GovProposal)
 
 		if prop.FindVoter(targetAddr) != nil {

--- a/ctrlers/gov/proposal/proposal.go
+++ b/ctrlers/gov/proposal/proposal.go
@@ -4,7 +4,7 @@ import (
 	"sort"
 	"sync"
 
-	v1 "github.com/beatoz/beatoz-go/ledger/v1"
+	v2 "github.com/beatoz/beatoz-go/ledger/v2"
 	"github.com/beatoz/beatoz-go/libs/jsonx"
 	"github.com/beatoz/beatoz-go/types"
 	"github.com/beatoz/beatoz-go/types/bytes"
@@ -75,7 +75,7 @@ func (prop *GovProposal) Decode(k, v []byte) xerrors.XError {
 	return nil
 }
 
-var _ v1.ILedgerItem = (*GovProposal)(nil)
+var _ v2.ILedgerItem = (*GovProposal)(nil)
 
 func (prop *GovProposal) Header() *GovProposalHeaderProto {
 	prop.mtx.RLock()

--- a/ctrlers/gov/query.go
+++ b/ctrlers/gov/query.go
@@ -3,7 +3,7 @@ package gov
 import (
 	"github.com/beatoz/beatoz-go/ctrlers/gov/proposal"
 	ctrlertypes "github.com/beatoz/beatoz-go/ctrlers/types"
-	v1 "github.com/beatoz/beatoz-go/ledger/v1"
+	v2 "github.com/beatoz/beatoz-go/ledger/v2"
 	"github.com/beatoz/beatoz-go/libs/jsonx"
 	"github.com/beatoz/beatoz-go/types/xerrors"
 	abcitypes "github.com/tendermint/tendermint/abci/types"
@@ -26,7 +26,7 @@ func (ctrler *GovCtrler) Query(req abcitypes.RequestQuery, opts ...ctrlertypes.O
 		txhash := req.Data
 		if len(txhash) == 0 {
 			var readProposals []*_response
-			if xerr := atledger.Seek(v1.KeyPrefixProposal, true, func(key v1.LedgerKey, item v1.ILedgerItem) xerrors.XError {
+			if xerr := atledger.Seek(v2.KeyPrefixProposal, true, func(key v2.LedgerKey, item v2.ILedgerItem) xerrors.XError {
 				prop, _ := item.(*proposal.GovProposal)
 				readProposals = append(readProposals, &_response{
 					Status:   "voting",
@@ -37,7 +37,7 @@ func (ctrler *GovCtrler) Query(req abcitypes.RequestQuery, opts ...ctrlertypes.O
 				return nil, xerrors.ErrQuery.Wrap(xerr)
 			}
 
-			if xerr = atledger.Seek(v1.KeyPrefixFrozenProp, true, func(key v1.LedgerKey, item v1.ILedgerItem) xerrors.XError {
+			if xerr = atledger.Seek(v2.KeyPrefixFrozenProp, true, func(key v2.LedgerKey, item v2.ILedgerItem) xerrors.XError {
 				prop, _ := item.(*proposal.GovProposal)
 				readProposals = append(readProposals, &_response{
 					Status:   "frozen",
@@ -54,11 +54,11 @@ func (ctrler *GovCtrler) Query(req abcitypes.RequestQuery, opts ...ctrlertypes.O
 			}
 			return v, nil
 		} else {
-			item, xerr := atledger.Get(v1.LedgerKeyProposal(txhash))
+			item, xerr := atledger.Get(v2.LedgerKeyProposal(txhash))
 			resp := &_response{Status: "voting"}
 			if xerr != nil {
 				if xerr.Code() == xerrors.ErrCodeNotFoundResult {
-					item, xerr = atledger.Get(v1.LedgerKeyFrozenProp(txhash))
+					item, xerr = atledger.Get(v2.LedgerKeyFrozenProp(txhash))
 					if xerr != nil {
 						return nil, xerrors.ErrQuery.Wrap(xerr)
 					}
@@ -78,7 +78,7 @@ func (ctrler *GovCtrler) Query(req abcitypes.RequestQuery, opts ...ctrlertypes.O
 			return v, nil
 		}
 	case "gov_params":
-		govParams, xerr := atledger.Get(v1.LedgerKeyGovParams())
+		govParams, xerr := atledger.Get(v2.LedgerKeyGovParams())
 		if xerr != nil {
 			return nil, xerrors.ErrQuery.Wrap(xerr)
 		}

--- a/ctrlers/mocks/acct/ctrler_mock.go
+++ b/ctrlers/mocks/acct/ctrler_mock.go
@@ -176,4 +176,8 @@ func (mock *AcctHandlerMock) ExecuteTrx(ctx *ctrlertypes.TrxContext) xerrors.XEr
 	return nil
 }
 
+func (mock *AcctHandlerMock) CacheHandlerContext(exec bool) (ctrlertypes.IAccountHandler, func() xerrors.XError) {
+	return mock, func() xerrors.XError { return nil }
+}
+
 var _ ctrlertypes.IAccountHandler = (*AcctHandlerMock)(nil)

--- a/ctrlers/mocks/gov/ctrler_mock.go
+++ b/ctrlers/mocks/gov/ctrler_mock.go
@@ -40,4 +40,8 @@ func (mock *GovHandlerMock) ExecuteTrx(context *ctrlertypes.TrxContext) xerrors.
 	panic("implement me")
 }
 
+func (mock *GovHandlerMock) CacheHandlerContext(exec bool) (ctrlertypes.IGovHandler, func() xerrors.XError) {
+	return mock, func() xerrors.XError { return nil }
+}
+
 var _ ctrlertypes.IGovHandler = (*GovHandlerMock)(nil)

--- a/ctrlers/mocks/supply/ctrler_mock.go
+++ b/ctrlers/mocks/supply/ctrler_mock.go
@@ -51,4 +51,8 @@ func (mock *SupplyHandlerMock) Burn(bctx *types.BlockContext, amt *uint256.Int) 
 	return nil
 }
 
+func (mock *SupplyHandlerMock) CacheHandlerContext(exec bool) (types.ISupplyHandler, func() xerrors.XError) {
+	return mock, func() xerrors.XError { return nil }
+}
+
 var _ types.ISupplyHandler = (*SupplyHandlerMock)(nil)

--- a/ctrlers/mocks/vpower/ctrler_mock.go
+++ b/ctrlers/mocks/vpower/ctrler_mock.go
@@ -213,4 +213,8 @@ func (mock *VPowerHandlerMock) Commit() ([]byte, int64, xerrors.XError) {
 	panic("implement me")
 }
 
+func (mock *VPowerHandlerMock) CacheHandlerContext(exec bool) (ctrlertypes.IVPowerHandler, func() xerrors.XError) {
+	return mock, func() xerrors.XError { return nil }
+}
+
 var _ ctrlertypes.IVPowerHandler = (*VPowerHandlerMock)(nil)

--- a/ctrlers/supply/ctrler.go
+++ b/ctrlers/supply/ctrler.go
@@ -2,10 +2,9 @@ package supply
 
 import (
 	"bytes"
-	"fmt"
 	cfg "github.com/beatoz/beatoz-go/cmd/config"
 	ctrlertypes "github.com/beatoz/beatoz-go/ctrlers/types"
-	v1 "github.com/beatoz/beatoz-go/ledger/v1"
+	v2 "github.com/beatoz/beatoz-go/ledger/v2"
 	"github.com/beatoz/beatoz-go/types/xerrors"
 	"github.com/holiman/uint256"
 	tmlog "github.com/tendermint/tendermint/libs/log"
@@ -13,7 +12,7 @@ import (
 )
 
 type SupplyCtrler struct {
-	supplyState v1.IStateLedger
+	supplyState v2.IStateLedger
 
 	lastTotalSupply *Supply
 
@@ -24,25 +23,25 @@ type SupplyCtrler struct {
 	mtx    sync.RWMutex
 }
 
-func defaultNewItem(key v1.LedgerKey) v1.ILedgerItem {
-	if bytes.HasPrefix(key, v1.KeyPrefixTotalSupply) {
+func defaultNewItem(key v2.LedgerKey) v2.ILedgerItem {
+	if bytes.HasPrefix(key, v2.KeyPrefixTotalSupply) {
 		return &Supply{}
-	} else if bytes.HasPrefix(key, v1.KeyPrefixReward) {
+	} else if bytes.HasPrefix(key, v2.KeyPrefixReward) {
 		return &Reward{}
 	}
-	panic(fmt.Errorf("invalid key prefix:0x%x", key[0]))
+	return v2.NewInvalidLedgerItem("unknown supply ledger key prefix: 0x%x", []byte(key))
 }
 
 func NewSupplyCtrler(config *cfg.Config, logger tmlog.Logger) (*SupplyCtrler, xerrors.XError) {
 	lg := logger.With("module", "beatoz_SupplyCtrler")
 
-	ledger, xerr := v1.NewStateLedger("supply", config.DBDir(), 21*1000, defaultNewItem, lg)
+	ledger, xerr := v2.NewStateLedger("supply", config.DBDir(), 21*1000, defaultNewItem, lg)
 	if xerr != nil {
 		return nil, xerr
 	}
 
 	// load supply info from ledger
-	item, xerr := ledger.Get(v1.LedgerKeyTotalSupply(), true)
+	item, xerr := ledger.Get(v2.LedgerKeyTotalSupply(), true)
 	if xerr != nil && !xerr.Contains(xerrors.ErrNotFoundResult) {
 		return nil, xerr
 	}
@@ -62,6 +61,24 @@ func NewSupplyCtrler(config *cfg.Config, logger tmlog.Logger) (*SupplyCtrler, xe
 		logger:          lg,
 		mtx:             sync.RWMutex{},
 	}, nil
+}
+
+func (ctrler *SupplyCtrler) CacheContext(exec bool) (*SupplyCtrler, func() xerrors.XError) {
+	ctrler.mtx.RLock()
+	defer ctrler.mtx.RUnlock()
+
+	cachedState, writeCache := ctrler.supplyState.CacheContext(exec)
+	return &SupplyCtrler{
+		supplyState:     cachedState,
+		lastTotalSupply: ctrler.lastTotalSupply,
+		reqCh:           ctrler.reqCh,
+		respCh:          ctrler.respCh,
+		logger:          ctrler.logger,
+	}, writeCache
+}
+
+func (ctrler *SupplyCtrler) CacheHandlerContext(exec bool) (ctrlertypes.ISupplyHandler, func() xerrors.XError) {
+	return ctrler.CacheContext(exec)
 }
 
 func (ctrler *SupplyCtrler) InitLedger(req interface{}) xerrors.XError {
@@ -94,7 +111,7 @@ func (ctrler *SupplyCtrler) ValidateTrx(ctx *ctrlertypes.TrxContext) xerrors.XEr
 			return xerrors.ErrInvalidTrxPayloadType
 		}
 
-		item, xerr := ctrler.supplyState.Get(v1.LedgerKeyReward(ctx.Tx.From), ctx.Exec)
+		item, xerr := ctrler.supplyState.Get(v2.LedgerKeyReward(ctx.Tx.From), ctx.Exec)
 		if xerr != nil {
 			return xerr
 		}

--- a/ctrlers/supply/ctrler_block.go
+++ b/ctrlers/supply/ctrler_block.go
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	ctrlertypes "github.com/beatoz/beatoz-go/ctrlers/types"
-	v1 "github.com/beatoz/beatoz-go/ledger/v1"
+	v2 "github.com/beatoz/beatoz-go/ledger/v2"
 	"github.com/beatoz/beatoz-go/types/xerrors"
 	abcitypes "github.com/tendermint/tendermint/abci/types"
 )
@@ -54,7 +54,7 @@ func (ctrler *SupplyCtrler) EndBlock(bctx *ctrlertypes.BlockContext) ([]abcitype
 	//
 	// Set supply info to ledger
 	if ctrler.lastTotalSupply.IsChanged() {
-		if xerr := ctrler.supplyState.Set(v1.LedgerKeyTotalSupply(), ctrler.lastTotalSupply, true); xerr != nil {
+		if xerr := ctrler.supplyState.Set(v2.LedgerKeyTotalSupply(), ctrler.lastTotalSupply, true); xerr != nil {
 			return nil, xerr
 		}
 		ctrler.lastTotalSupply.ResetChanged()

--- a/ctrlers/supply/ctrler_query.go
+++ b/ctrlers/supply/ctrler_query.go
@@ -3,7 +3,7 @@ package supply
 import (
 	"fmt"
 	ctrlertypes "github.com/beatoz/beatoz-go/ctrlers/types"
-	v1 "github.com/beatoz/beatoz-go/ledger/v1"
+	v2 "github.com/beatoz/beatoz-go/ledger/v2"
 	"github.com/beatoz/beatoz-go/libs/jsonx"
 	"github.com/beatoz/beatoz-go/types"
 	"github.com/beatoz/beatoz-go/types/xerrors"
@@ -29,7 +29,7 @@ func (ctrler *SupplyCtrler) queryReward(height int64, address types.Address) ([]
 	if xerr != nil {
 		return nil, xerrors.ErrQuery.Wrap(xerr)
 	}
-	item, xerr := atledger.Get(v1.LedgerKeyReward(address))
+	item, xerr := atledger.Get(v2.LedgerKeyReward(address))
 	if xerr != nil && !xerr.Contains(xerrors.ErrNotFoundResult) {
 		return nil, xerrors.ErrQuery.Wrap(xerr)
 	}
@@ -52,7 +52,7 @@ func (ctrler *SupplyCtrler) queryTotalSupply(height int64) ([]byte, xerrors.XErr
 	}
 
 	// get supply info from ledger
-	item, xerr := atledger.Get(v1.LedgerKeyTotalSupply())
+	item, xerr := atledger.Get(v2.LedgerKeyTotalSupply())
 	if xerr != nil {
 		return nil, xerrors.ErrQuery.Wrap(xerr)
 	}

--- a/ctrlers/supply/ctrler_reward.go
+++ b/ctrlers/supply/ctrler_reward.go
@@ -2,7 +2,7 @@ package supply
 
 import (
 	"github.com/beatoz/beatoz-go/ctrlers/types"
-	v1 "github.com/beatoz/beatoz-go/ledger/v1"
+	v2 "github.com/beatoz/beatoz-go/ledger/v2"
 	btztypes "github.com/beatoz/beatoz-go/types"
 	"github.com/beatoz/beatoz-go/types/bytes"
 	"github.com/beatoz/beatoz-go/types/xerrors"
@@ -22,7 +22,7 @@ func (ctrler *SupplyCtrler) distReward(rewards []*mintedReward, height int64, po
 
 func (ctrler *SupplyCtrler) distRewardToState(rewards []*mintedReward, height int64) xerrors.XError {
 	for _, nrwd := range rewards {
-		item, xerr := ctrler.supplyState.Get(v1.LedgerKeyReward(nrwd.addr), true)
+		item, xerr := ctrler.supplyState.Get(v2.LedgerKeyReward(nrwd.addr), true)
 		if xerr != nil && !xerr.Contains(xerrors.ErrNotFoundResult) {
 			return xerr
 		}
@@ -33,7 +33,7 @@ func (ctrler *SupplyCtrler) distRewardToState(rewards []*mintedReward, height in
 		}
 		_ = rwd.Issue(nrwd.amt, height)
 
-		if xerr := ctrler.supplyState.Set(v1.LedgerKeyReward(nrwd.addr), rwd, true); xerr != nil {
+		if xerr := ctrler.supplyState.Set(v2.LedgerKeyReward(nrwd.addr), rwd, true); xerr != nil {
 			return xerr
 		}
 	}
@@ -45,7 +45,7 @@ func (ctrler *SupplyCtrler) distRewardToPool() xerrors.XError {
 }
 
 func (ctrler *SupplyCtrler) readReward(addr btztypes.Address) (*Reward, xerrors.XError) {
-	item, xerr := ctrler.supplyState.Get(v1.LedgerKeyReward(addr), true)
+	item, xerr := ctrler.supplyState.Get(v2.LedgerKeyReward(addr), true)
 	if xerr != nil {
 		return nil, xerr
 	}
@@ -58,11 +58,11 @@ func (ctrler *SupplyCtrler) readReward(addr btztypes.Address) (*Reward, xerrors.
 func (ctrler *SupplyCtrler) withdrawReward(currReward *Reward, amt *uint256.Int, height int64, acctHandler types.IAccountHandler, exec bool) xerrors.XError {
 	_ = currReward.Withdraw(amt, height)
 	if currReward.CumulatedAmount().IsZero() {
-		if xerr := ctrler.supplyState.Del(v1.LedgerKeyReward(currReward.Address()), exec); xerr != nil {
+		if xerr := ctrler.supplyState.Del(v2.LedgerKeyReward(currReward.Address()), exec); xerr != nil {
 			return xerr
 		}
 	} else {
-		if xerr := ctrler.supplyState.Set(v1.LedgerKeyReward(currReward.Address()), currReward, exec); xerr != nil {
+		if xerr := ctrler.supplyState.Set(v2.LedgerKeyReward(currReward.Address()), currReward, exec); xerr != nil {
 			return xerr
 		}
 	}

--- a/ctrlers/supply/ctrler_reward_test.go
+++ b/ctrlers/supply/ctrler_reward_test.go
@@ -2,18 +2,37 @@ package supply
 
 import (
 	"fmt"
+	btzcfg "github.com/beatoz/beatoz-go/cmd/config"
+	"github.com/beatoz/beatoz-go/ctrlers"
+	"github.com/beatoz/beatoz-go/ctrlers/account"
+	"github.com/beatoz/beatoz-go/ctrlers/mocks"
 	vpowmock "github.com/beatoz/beatoz-go/ctrlers/mocks/vpower"
 	"github.com/beatoz/beatoz-go/ctrlers/types"
-	v1 "github.com/beatoz/beatoz-go/ledger/v1"
+	v2 "github.com/beatoz/beatoz-go/ledger/v2"
 	types2 "github.com/beatoz/beatoz-go/types"
 	"github.com/beatoz/beatoz-go/types/bytes"
+	"github.com/beatoz/beatoz-go/types/xerrors"
 	"github.com/beatoz/beatoz-sdk-go/web3"
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
+	"github.com/tendermint/tendermint/libs/log"
 	"os"
 	"testing"
 	"time"
 )
+
+type rewardFailingAcctHandler struct {
+	types.IAccountHandler
+}
+
+func (handler *rewardFailingAcctHandler) Reward(_ types2.Address, _ *uint256.Int, _ bool) xerrors.XError {
+	return xerrors.ErrInvalidAmount.Wrapf("forced account reward failure")
+}
+
+func (handler *rewardFailingAcctHandler) CacheHandlerContext(exec bool) (types.IAccountHandler, func() xerrors.XError) {
+	cached, writeCache := handler.IAccountHandler.(types.ICacheableAccountHandler).CacheHandlerContext(exec)
+	return &rewardFailingAcctHandler{IAccountHandler: cached}, writeCache
+}
 
 func Test_Withdraw(t *testing.T) {
 	require.NoError(t, os.RemoveAll(config.RootDir))
@@ -62,7 +81,7 @@ func Test_Withdraw(t *testing.T) {
 				beforeWithdrawn := accumRwd.WithdrawnAmount()
 				beforeCummAmt := accumRwd.CumulatedAmount()
 
-				item, xerr := ctrler.supplyState.Get(v1.LedgerKeyReward(mintRwd.addr), true)
+				item, xerr := ctrler.supplyState.Get(v2.LedgerKeyReward(mintRwd.addr), true)
 				require.NoError(t, xerr)
 
 				rwd := item.(*Reward)
@@ -87,4 +106,77 @@ func Test_Withdraw(t *testing.T) {
 	}
 	require.NoError(t, ctrler.Close())
 	require.NoError(t, os.RemoveAll(config.RootDir))
+}
+
+func TestWithdrawRollback(t *testing.T) {
+	localConfig := btzcfg.DefaultConfig("1234")
+	localConfig.SetRoot(t.TempDir())
+	types.InitSigner(localConfig.ChainId())
+
+	acctCtrler, err := account.NewAcctCtrler(localConfig, log.NewNopLogger())
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, acctCtrler.Close())
+	}()
+
+	supplyCtrler, xerr := NewSupplyCtrler(localConfig, log.NewNopLogger())
+	require.NoError(t, xerr)
+	defer func() {
+		require.NoError(t, supplyCtrler.Close())
+	}()
+
+	wal := web3.NewWallet(nil)
+	acct := wal.GetAccount()
+	acct.SetBalance(uint256.NewInt(1_000_000_000))
+	require.NoError(t, acctCtrler.SetAccount(acct, true))
+	_, _, xerr = acctCtrler.Commit()
+	require.NoError(t, xerr)
+
+	reward := NewReward(wal.Address())
+	require.NoError(t, reward.Issue(uint256.NewInt(1000), 1))
+	require.NoError(t, supplyCtrler.supplyState.Set(v2.LedgerKeyReward(wal.Address()), reward, true))
+	_, _, xerr = supplyCtrler.Commit()
+	require.NoError(t, xerr)
+
+	before, xerr := supplyCtrler.readReward(wal.Address())
+	require.NoError(t, xerr)
+	beforeCumulated := before.CumulatedAmount()
+	beforeWithdrawn := before.WithdrawnAmount()
+	beforeBalance := acct.GetBalance()
+
+	reqAmt := uint256.NewInt(100)
+	tx := web3.NewTrxWithdraw(wal.Address(), wal.Address(), wal.GetNonce(), govMock.MinTrxGas(), govMock.GasPrice(), reqAmt)
+	_, _, err = wal.SignTrxRLP(tx, localConfig.ChainIdHex())
+	require.NoError(t, err)
+
+	failingAcct := &rewardFailingAcctHandler{IAccountHandler: acctCtrler}
+	bctx := types.TempBlockContext(localConfig.ChainIdHex(), 2, time.Now(), govMock, failingAcct, nil, supplyCtrler, nil)
+	txctx, xerr := mocks.MakeTrxCtxWithTrxBctx(tx, bctx, true)
+	require.NoError(t, xerr)
+	require.NoError(t, supplyCtrler.ValidateTrx(txctx))
+
+	scope := ctrlers.NewBlockCacheContext(bctx, true)
+	require.NotNil(t, scope)
+	defer scope.Restore(bctx)
+
+	xerr = bctx.SupplyHandler.ExecuteTrx(txctx)
+	require.Error(t, xerr)
+	require.True(t, xerr.Contains(xerrors.ErrInvalidAmount))
+	scope.Restore(bctx)
+
+	after, xerr := supplyCtrler.readReward(wal.Address())
+	require.NoError(t, xerr)
+	require.Equal(t, beforeCumulated.Dec(), after.CumulatedAmount().Dec())
+	require.Equal(t, beforeWithdrawn.Dec(), after.WithdrawnAmount().Dec())
+
+	afterAcct := acctCtrler.FindAccount(wal.Address(), true)
+	require.NotNil(t, afterAcct)
+	require.Equal(t, beforeBalance.Dec(), afterAcct.GetBalance().Dec())
+
+	_, _, xerr = supplyCtrler.Commit()
+	require.NoError(t, xerr)
+	committed, xerr := supplyCtrler.readReward(wal.Address())
+	require.NoError(t, xerr)
+	require.Equal(t, beforeCumulated.Dec(), committed.CumulatedAmount().Dec())
+	require.Equal(t, beforeWithdrawn.Dec(), committed.WithdrawnAmount().Dec())
 }

--- a/ctrlers/supply/ctrler_test.go
+++ b/ctrlers/supply/ctrler_test.go
@@ -63,6 +63,16 @@ func Test_InitLedger(t *testing.T) {
 	require.NoError(t, os.RemoveAll(config.RootDir))
 }
 
+func TestDefaultNewItemGuards(t *testing.T) {
+	for _, key := range [][]byte{nil, []byte{0xff}} {
+		require.NotPanics(t, func() {
+			item := defaultNewItem(key)
+			require.NotNil(t, item)
+			require.Error(t, item.Decode(key, nil))
+		})
+	}
+}
+
 func initLedger(initSupply *uint256.Int) (*SupplyCtrler, xerrors.XError) {
 	ctrler, xerr := NewSupplyCtrler(config, log.NewNopLogger() /*log.NewTMLogger(os.Stdout)*/)
 	if xerr != nil {

--- a/ctrlers/supply/reward.go
+++ b/ctrlers/supply/reward.go
@@ -2,7 +2,7 @@ package supply
 
 import (
 	"fmt"
-	v1 "github.com/beatoz/beatoz-go/ledger/v1"
+	v2 "github.com/beatoz/beatoz-go/ledger/v2"
 	"github.com/beatoz/beatoz-go/libs/jsonx"
 	"github.com/beatoz/beatoz-go/types"
 	"github.com/beatoz/beatoz-go/types/xerrors"
@@ -59,7 +59,7 @@ func (rwd *Reward) toProto() {
 	rwd._proto.XCumulated = rwd.cumulated.Bytes()
 }
 
-var _ v1.ILedgerItem = (*Reward)(nil)
+var _ v2.ILedgerItem = (*Reward)(nil)
 
 func (rwd *Reward) MarshalJSON() ([]byte, error) {
 	_tmp := &struct {

--- a/ctrlers/supply/supply.go
+++ b/ctrlers/supply/supply.go
@@ -1,7 +1,7 @@
 package supply
 
 import (
-	v1 "github.com/beatoz/beatoz-go/ledger/v1"
+	v2 "github.com/beatoz/beatoz-go/ledger/v2"
 	"github.com/beatoz/beatoz-go/types/xerrors"
 	"github.com/holiman/uint256"
 	"google.golang.org/protobuf/proto"
@@ -92,4 +92,4 @@ func (s *Supply) ResetChanged() {
 	s.changed = false
 }
 
-var _ v1.ILedgerItem = (*Supply)(nil)
+var _ v2.ILedgerItem = (*Supply)(nil)

--- a/ctrlers/types/handlers.go
+++ b/ctrlers/types/handlers.go
@@ -70,6 +70,11 @@ type IGovHandler interface {
 	IBlockHandler
 }
 
+type ICacheableGovHandler interface {
+	IGovHandler
+	CacheHandlerContext(bool) (IGovHandler, func() xerrors.XError)
+}
+
 type IAccountHandler interface {
 	ITrxHandler
 	IBlockHandler
@@ -83,6 +88,11 @@ type IAccountHandler interface {
 	SubBalance(types.Address, *uint256.Int, bool) xerrors.XError
 	SetBalance(types.Address, *uint256.Int, bool) xerrors.XError
 	SimuAcctCtrlerAt(int64) (IAccountHandler, xerrors.XError)
+}
+
+type ICacheableAccountHandler interface {
+	IAccountHandler
+	CacheHandlerContext(bool) (IAccountHandler, func() xerrors.XError)
 }
 
 type IStakeHandler interface {
@@ -107,10 +117,20 @@ type IVPowerHandler interface {
 	ComputeWeight(int64, int64, int64, int32, *uint256.Int) (IWeightResult, xerrors.XError)
 }
 
+type ICacheableVPowerHandler interface {
+	IVPowerHandler
+	CacheHandlerContext(bool) (IVPowerHandler, func() xerrors.XError)
+}
+
 type ISupplyHandler interface {
 	ITrxHandler
 	IBlockHandler
 	TotalSupply() *uint256.Int
 	RequestMint(bctx *BlockContext)
 	Burn(bctx *BlockContext, amt *uint256.Int) xerrors.XError
+}
+
+type ICacheableSupplyHandler interface {
+	ISupplyHandler
+	CacheHandlerContext(bool) (ISupplyHandler, func() xerrors.XError)
 }

--- a/ctrlers/vpower/ctrler.go
+++ b/ctrlers/vpower/ctrler.go
@@ -9,7 +9,7 @@ import (
 
 	cfg "github.com/beatoz/beatoz-go/cmd/config"
 	ctrlertypes "github.com/beatoz/beatoz-go/ctrlers/types"
-	v1 "github.com/beatoz/beatoz-go/ledger/v1"
+	v2 "github.com/beatoz/beatoz-go/ledger/v2"
 	"github.com/beatoz/beatoz-go/types"
 	"github.com/beatoz/beatoz-go/types/bytes"
 	"github.com/beatoz/beatoz-go/types/xerrors"
@@ -19,7 +19,7 @@ import (
 )
 
 type VPowerCtrler struct {
-	vpowerState v1.IStateLedger
+	vpowerState v2.IStateLedger
 
 	allDelegatees  []*Delegatee
 	lastValidators []*Delegatee
@@ -30,23 +30,23 @@ type VPowerCtrler struct {
 	mtx    sync.RWMutex
 }
 
-func defaultNewItem(key v1.LedgerKey) v1.ILedgerItem {
-	if bytes2.HasPrefix(key, v1.KeyPrefixVPower) {
+func defaultNewItem(key v2.LedgerKey) v2.ILedgerItem {
+	if bytes2.HasPrefix(key, v2.KeyPrefixVPower) {
 		return &VPower{}
-	} else if bytes2.HasPrefix(key, v1.KeyPrefixDelegatee) {
+	} else if bytes2.HasPrefix(key, v2.KeyPrefixDelegatee) {
 		return &Delegatee{}
-	} else if bytes2.HasPrefix(key, v1.KeyPrefixFrozenVPower) {
+	} else if bytes2.HasPrefix(key, v2.KeyPrefixFrozenVPower) {
 		return &FrozenVPower{}
-	} else if bytes2.HasPrefix(key, v1.KeyPrefixMissedBlockCount) {
+	} else if bytes2.HasPrefix(key, v2.KeyPrefixMissedBlockCount) {
 		return new(BlockCount)
 	}
-	panic(fmt.Errorf("invalid key prefix:0x%x", key[0]))
+	return v2.NewInvalidLedgerItem("unknown vpower ledger key prefix: 0x%x", []byte(key))
 }
 
 func NewVPowerCtrler(config *cfg.Config, maxValCnt int, logger tmlog.Logger) (*VPowerCtrler, xerrors.XError) {
 	lg := logger.With("module", "beatoz_VPowerCtrler")
 
-	powersState, xerr := v1.NewStateLedger("vpows", config.DBDir(), 21*1000, defaultNewItem, lg)
+	powersState, xerr := v2.NewStateLedger("vpows", config.DBDir(), 21*1000, defaultNewItem, lg)
 	if xerr != nil {
 		return nil, xerr
 	}
@@ -60,6 +60,29 @@ func NewVPowerCtrler(config *cfg.Config, maxValCnt int, logger tmlog.Logger) (*V
 		return nil, xerr
 	}
 	return ret, nil
+}
+
+func (ctrler *VPowerCtrler) CacheContext(exec bool) (*VPowerCtrler, func() xerrors.XError) {
+	ctrler.mtx.RLock()
+	defer ctrler.mtx.RUnlock()
+
+	cachedState, writeCache := ctrler.vpowerState.CacheContext(exec)
+	var cachedLimiter *VPowerLimiter
+	if ctrler.vpowLimiter != nil {
+		limiter := *ctrler.vpowLimiter
+		cachedLimiter = &limiter
+	}
+	return &VPowerCtrler{
+		vpowerState:    cachedState,
+		allDelegatees:  copyDelegateeArray(ctrler.allDelegatees),
+		lastValidators: copyDelegateeArray(ctrler.lastValidators),
+		vpowLimiter:    cachedLimiter,
+		logger:         ctrler.logger,
+	}, writeCache
+}
+
+func (ctrler *VPowerCtrler) CacheHandlerContext(exec bool) (ctrlertypes.IVPowerHandler, func() xerrors.XError) {
+	return ctrler.CacheContext(exec)
 }
 
 // InitLedger creates the voting power of the genesis validators.
@@ -465,7 +488,7 @@ func (ctrler *VPowerCtrler) PowerOf(from types.Address) int64 {
 	defer ctrler.mtx.RUnlock()
 
 	delegatePower := int64(0)
-	_ = ctrler.seekVPowersOf(from, func(key v1.LedgerKey, item v1.ILedgerItem) xerrors.XError {
+	_ = ctrler.seekVPowersOf(from, func(key v2.LedgerKey, item v2.ILedgerItem) xerrors.XError {
 		vpow, _ := item.(*VPower)
 		delegatePower += vpow.SumPower
 		return nil
@@ -480,7 +503,7 @@ func (ctrler *VPowerCtrler) DelegatedPowerOf(addr types.Address) int64 {
 }
 
 // DEPRECATED
-func (ctrler *VPowerCtrler) ImitableState(h int64) (v1.IImitable, xerrors.XError) {
+func (ctrler *VPowerCtrler) ImitableState(h int64) (v2.IImitable, xerrors.XError) {
 	ctrler.mtx.RLock()
 	defer ctrler.mtx.RUnlock()
 

--- a/ctrlers/vpower/ctrler_bonding_test.go
+++ b/ctrlers/vpower/ctrler_bonding_test.go
@@ -14,7 +14,7 @@ import (
 	beatozcfg "github.com/beatoz/beatoz-go/cmd/config"
 	"github.com/beatoz/beatoz-go/ctrlers/mocks"
 	ctrlertypes "github.com/beatoz/beatoz-go/ctrlers/types"
-	v1 "github.com/beatoz/beatoz-go/ledger/v1"
+	v2 "github.com/beatoz/beatoz-go/ledger/v2"
 	"github.com/beatoz/beatoz-go/libs"
 	"github.com/beatoz/beatoz-go/types"
 	bytes2 "github.com/beatoz/beatoz-go/types/bytes"
@@ -46,10 +46,10 @@ func Test_InitLedger(t *testing.T) {
 	}
 
 	totalPower1 := int64(0)
-	xerr = ctrler.vpowerState.Seek(v1.KeyPrefixDelegatee, true, func(key v1.LedgerKey, item v1.ILedgerItem) xerrors.XError {
+	xerr = ctrler.vpowerState.Seek(v2.KeyPrefixDelegatee, true, func(key v2.LedgerKey, item v2.ILedgerItem) xerrors.XError {
 		dgt, _ := item.(*Delegatee)
-		require.EqualValues(t, v1.LedgerKeyDelegatee(dgt.addr), key)
-		require.EqualValues(t, v1.LedgerKeyDelegatee(dgt.addr), dgt.key)
+		require.EqualValues(t, v2.LedgerKeyDelegatee(dgt.addr), key)
+		require.EqualValues(t, v2.LedgerKeyDelegatee(dgt.addr), dgt.key)
 
 		var valUp *abcitypes.ValidatorUpdate
 		var wallet *web3.Wallet
@@ -78,9 +78,9 @@ func Test_InitLedger(t *testing.T) {
 	}, true)
 
 	totalPower2 := int64(0)
-	xerr = ctrler.vpowerState.Seek(v1.KeyPrefixVPower, true, func(key v1.LedgerKey, item v1.ILedgerItem) xerrors.XError {
+	xerr = ctrler.vpowerState.Seek(v2.KeyPrefixVPower, true, func(key v2.LedgerKey, item v2.ILedgerItem) xerrors.XError {
 		vpow, _ := item.(*VPower)
-		require.EqualValues(t, v1.LedgerKeyVPower(vpow.from, vpow.to), key)
+		require.EqualValues(t, v2.LedgerKeyVPower(vpow.from, vpow.to), key)
 		require.EqualValues(t, key, vpow.key)
 
 		var valUp *abcitypes.ValidatorUpdate
@@ -334,21 +334,21 @@ func Test_Unbonding(t *testing.T) {
 	txctx1, xerr := doUndelegate(ctrler, acctMock.RandWallet(), valWal.Address(), lastHeight+1, txhash0)
 	require.Error(t, xerr)
 	require.True(t, xerr.Contains(xerrors.ErrNotFoundStake))
-	require.Equal(t, 0, ctrler.countOf(v1.KeyPrefixFrozenVPower, true))
+	require.Equal(t, 0, ctrler.countOf(v2.KeyPrefixFrozenVPower, true))
 	// 2. wrong to
 	txctx1, xerr = doUndelegate(ctrler, fromWal, types.RandAddress(), lastHeight+1, txhash0)
 	require.Error(t, xerr)
 	require.True(t, xerr.Contains(xerrors.ErrNotFoundDelegatee))
-	require.Equal(t, 0, ctrler.countOf(v1.KeyPrefixFrozenVPower, true))
+	require.Equal(t, 0, ctrler.countOf(v2.KeyPrefixFrozenVPower, true))
 	// 3. wrong txhash
 	txctx1, xerr = doUndelegate(ctrler, fromWal, valWal.Address(), lastHeight+1, bytes2.RandBytes(32))
 	require.Error(t, xerr)
 	require.True(t, xerr.Contains(xerrors.ErrNotFoundStake))
-	require.Equal(t, 0, ctrler.countOf(v1.KeyPrefixFrozenVPower, true))
+	require.Equal(t, 0, ctrler.countOf(v2.KeyPrefixFrozenVPower, true))
 	// 4. all ok
 	txctx1, xerr = doUndelegate(ctrler, fromWal, valWal.Address(), lastHeight+1, txhash0)
 	require.NoError(t, xerr)
-	require.Equal(t, 1, ctrler.countOf(v1.KeyPrefixFrozenVPower, true))
+	require.Equal(t, 1, ctrler.countOf(v2.KeyPrefixFrozenVPower, true))
 
 	// commit
 	_, lastHeight, xerr = ctrler.Commit()
@@ -359,7 +359,7 @@ func Test_Unbonding(t *testing.T) {
 	require.NoError(t, xerr, dgtee0.key)
 	require.Equal(t, totalPower0, dgtee1.SumPower)
 	require.Equal(t, selfPower0, dgtee1.SelfPower)
-	require.Equal(t, 1, ctrler.countOf(v1.KeyPrefixFrozenVPower, true))
+	require.Equal(t, 1, ctrler.countOf(v2.KeyPrefixFrozenVPower, true))
 	refundHeight := lastHeight + govMock.LazyUnbondingBlocks()
 	frozen, xerr := ctrler.readFrozenVPower(refundHeight, fromWal.Address(), true)
 	require.NoError(t, xerr)
@@ -373,7 +373,7 @@ func Test_Unbonding(t *testing.T) {
 	// nothing happens because refundHeight has not been reached.
 	xerr = ctrler._unfreezePowerChunk(refundHeight-1, acctMock)
 	require.NoError(t, xerr)
-	require.Equal(t, 1, ctrler.countOf(v1.KeyPrefixFrozenVPower, true))
+	require.Equal(t, 1, ctrler.countOf(v2.KeyPrefixFrozenVPower, true))
 	frozen, xerr = ctrler.readFrozenVPower(refundHeight, fromWal.Address(), true)
 	require.NoError(t, xerr)
 	require.NotNil(t, frozen)
@@ -386,7 +386,7 @@ func Test_Unbonding(t *testing.T) {
 	// frozen vpower has been removed because refundHeight has been reached.
 	xerr = ctrler._unfreezePowerChunk(refundHeight, acctMock)
 	require.NoError(t, xerr)
-	require.Equal(t, 0, ctrler.countOf(v1.KeyPrefixFrozenVPower, true))
+	require.Equal(t, 0, ctrler.countOf(v2.KeyPrefixFrozenVPower, true))
 	frozen, xerr = ctrler.readFrozenVPower(refundHeight, fromWal.Address(), true)
 	require.Error(t, xerr)
 	require.Nil(t, frozen)
@@ -561,9 +561,9 @@ func Test_Freezing(t *testing.T) {
 		var expectedBalances []*uint256.Int
 		// frozen vpowers to be un-frozen (thawed) at height 'h'
 		xerr = ctrler.vpowerState.Seek(
-			v1.LedgerKeyFrozenVPower(h, nil),
+			v2.LedgerKeyFrozenVPower(h, nil),
 			true,
-			func(key v1.LedgerKey, item v1.ILedgerItem) xerrors.XError {
+			func(key v2.LedgerKey, item v2.ILedgerItem) xerrors.XError {
 				frozen, _ := item.(*FrozenVPower)
 				sum := int64(0)
 				for _, pc := range frozen.PowerChunks {
@@ -608,9 +608,9 @@ func Test_Freezing(t *testing.T) {
 	}
 
 	ctrler.vpowerState.Seek(
-		v1.KeyPrefixFrozenVPower,
+		v2.KeyPrefixFrozenVPower,
 		true,
-		func(key v1.LedgerKey, item v1.ILedgerItem) xerrors.XError {
+		func(key v2.LedgerKey, item v2.ILedgerItem) xerrors.XError {
 			frozen := item.(*FrozenVPower)
 			_h := key[1:9]
 			h := binary.BigEndian.Uint64(_h)
@@ -619,14 +619,14 @@ func Test_Freezing(t *testing.T) {
 		},
 		true,
 	)
-	require.Equal(t, 0, ctrler.countOf(v1.KeyPrefixFrozenVPower, true))
+	require.Equal(t, 0, ctrler.countOf(v2.KeyPrefixFrozenVPower, true))
 
 	// at now, all delegated power has been frozen.
 	// only initial vpowers are remained.
 	fmt.Println("return to initial vpowers - last committed height", lastHeight)
 
 	for _, v := range valWallets {
-		item, xerr := ctrler.vpowerState.Get(v1.LedgerKeyDelegatee(v.Address()), true)
+		item, xerr := ctrler.vpowerState.Get(v2.LedgerKeyDelegatee(v.Address()), true)
 		require.NoError(t, xerr)
 
 		dgtee, _ := item.(*Delegatee)
@@ -669,9 +669,9 @@ func testRandDelegate(t *testing.T, count int, ctrler *VPowerCtrler, valWallets 
 
 	// check all vpowers
 	var txhashes1 []bytes2.HexBytes
-	xerr := ctrler.vpowerState.Seek(v1.KeyPrefixVPower, true, func(key v1.LedgerKey, item v1.ILedgerItem) xerrors.XError {
+	xerr := ctrler.vpowerState.Seek(v2.KeyPrefixVPower, true, func(key v2.LedgerKey, item v2.ILedgerItem) xerrors.XError {
 		vpow, _ := item.(*VPower)
-		require.EqualValues(t, v1.LedgerKeyVPower(vpow.from, vpow.to), key)
+		require.EqualValues(t, v2.LedgerKeyVPower(vpow.from, vpow.to), key)
 		require.EqualValues(t, key, vpow.key)
 
 		sum := int64(0)
@@ -715,10 +715,10 @@ func testRandDelegate(t *testing.T, count int, ctrler *VPowerCtrler, valWallets 
 	}
 
 	// check delegatees
-	xerr = ctrler.vpowerState.Seek(v1.KeyPrefixDelegatee, true, func(key v1.LedgerKey, item v1.ILedgerItem) xerrors.XError {
+	xerr = ctrler.vpowerState.Seek(v2.KeyPrefixDelegatee, true, func(key v2.LedgerKey, item v2.ILedgerItem) xerrors.XError {
 		dgtee, _ := item.(*Delegatee)
 		require.EqualValues(t, crypto.PubKeyBytes2Addr(dgtee.PubKey), dgtee.addr)
-		require.EqualValues(t, v1.LedgerKeyDelegatee(dgtee.addr), key)
+		require.EqualValues(t, v2.LedgerKeyDelegatee(dgtee.addr), key)
 		require.EqualValues(t, key, dgtee.key)
 		require.Equal(t, sumPowerOfDgtee[dgtee.addr.String()], dgtee.SumPower)
 		require.Equal(t, len(fromAddrsOfDgtee[dgtee.addr.String()]), len(dgtee.Delegators))

--- a/ctrlers/vpower/ctrler_query.go
+++ b/ctrlers/vpower/ctrler_query.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 
 	ctrlertypes "github.com/beatoz/beatoz-go/ctrlers/types"
-	v1 "github.com/beatoz/beatoz-go/ledger/v1"
+	v2 "github.com/beatoz/beatoz-go/ledger/v2"
 	"github.com/beatoz/beatoz-go/libs"
 	"github.com/beatoz/beatoz-go/libs/jsonx"
 	"github.com/beatoz/beatoz-go/types"
@@ -47,7 +47,7 @@ func (ctrler *VPowerCtrler) queryStakes(height int64, addr types.Address) ([]byt
 		return nil, xerrors.ErrQuery.Wrap(xerr)
 	}
 
-	xerr = atledger.Seek(v1.LedgerKeyVPower(addr, nil), true, func(key v1.LedgerKey, item v1.ILedgerItem) xerrors.XError {
+	xerr = atledger.Seek(v2.LedgerKeyVPower(addr, nil), true, func(key v2.LedgerKey, item v2.ILedgerItem) xerrors.XError {
 		vpow, _ := item.(*VPower)
 		for _, pc := range vpow.PowerChunks {
 			ret = append(ret, &respStake{
@@ -101,14 +101,14 @@ func (ctrler *VPowerCtrler) queryDelegatee(height int64, addr types.Address) ([]
 		return nil, xerrors.ErrQuery.Wrap(xerr)
 	}
 
-	bc, xerr := atledger.Get(v1.LedgerKeyMissedBlockCount(addr))
+	bc, xerr := atledger.Get(v2.LedgerKeyMissedBlockCount(addr))
 	if xerr != nil && !xerr.Contains(xerrors.ErrNotFoundResult) {
 		return nil, xerrors.ErrQuery.Wrap(xerr)
 	}
 	_ptr, _ := bc.(*BlockCount)
 	n := _ptr.Int64()
 
-	item, xerr := atledger.Get(v1.LedgerKeyDelegatee(addr))
+	item, xerr := atledger.Get(v2.LedgerKeyDelegatee(addr))
 	if xerr != nil {
 		return nil, xerrors.ErrQuery.Wrap(xerr)
 	}
@@ -119,7 +119,7 @@ func (ctrler *VPowerCtrler) queryDelegatee(height int64, addr types.Address) ([]
 	for i, _addr := range dgtee.Delegators {
 		dgtors[i] = _addr
 
-		item, xerr = atledger.Get(v1.LedgerKeyVPower(_addr, dgtee.addr))
+		item, xerr = atledger.Get(v2.LedgerKeyVPower(_addr, dgtee.addr))
 		if xerr != nil {
 			return nil, xerrors.ErrQuery.Wrap(xerr)
 		}
@@ -160,7 +160,7 @@ func (ctrler *VPowerCtrler) queryTotalPower(height int64) ([]byte, xerrors.XErro
 	}
 
 	ret := int64(0)
-	xerr = atledger.Seek(v1.KeyPrefixDelegatee, true, func(key v1.LedgerKey, item v1.ILedgerItem) xerrors.XError {
+	xerr = atledger.Seek(v2.KeyPrefixDelegatee, true, func(key v2.LedgerKey, item v2.ILedgerItem) xerrors.XError {
 		d, _ := item.(*Delegatee)
 		ret += d.SumPower
 		return nil
@@ -182,7 +182,7 @@ func (ctrler *VPowerCtrler) queryVotingPower(height int64, getMaxValCnt, getMinV
 	minValPower := getMinValPower().(int64)
 
 	var delegatees OrderByPowerDelegatees
-	xerr = atledger.Seek(v1.KeyPrefixDelegatee, true, func(key v1.LedgerKey, item v1.ILedgerItem) xerrors.XError {
+	xerr = atledger.Seek(v2.KeyPrefixDelegatee, true, func(key v2.LedgerKey, item v2.ILedgerItem) xerrors.XError {
 		d, _ := item.(*Delegatee)
 		if d.SelfPower < minValPower {
 			return nil // continue

--- a/ctrlers/vpower/ctrler_test.go
+++ b/ctrlers/vpower/ctrler_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/beatoz/beatoz-go/ctrlers/mocks/acct"
 	"github.com/beatoz/beatoz-go/ctrlers/mocks/gov"
 	ctrlertypes "github.com/beatoz/beatoz-go/ctrlers/types"
+	v2 "github.com/beatoz/beatoz-go/ledger/v2"
 	btztypes "github.com/beatoz/beatoz-go/types"
 	"github.com/beatoz/beatoz-go/types/bytes"
 	"github.com/beatoz/beatoz-go/types/crypto"
@@ -110,6 +111,40 @@ func Test_NewValidatorSet(t *testing.T) {
 	}
 	require.NoError(t, ctrler.Close())
 	require.NoError(t, os.RemoveAll(config.DBDir()))
+}
+
+func TestDefaultNewItemGuards(t *testing.T) {
+	for _, key := range [][]byte{nil, []byte{0xff}} {
+		require.NotPanics(t, func() {
+			item := defaultNewItem(key)
+			require.NotNil(t, item)
+			require.Error(t, item.Decode(key, nil))
+		})
+	}
+}
+
+func TestVPowerDecodeKeyGuards(t *testing.T) {
+	for _, key := range [][]byte{
+		nil,
+		v2.KeyPrefixVPower,
+		append(v2.LedgerKeyVPower(btztypes.RandAddress(), btztypes.RandAddress()), 0x00),
+	} {
+		item := &VPower{}
+		require.NotPanics(t, func() {
+			require.Error(t, item.Decode(key, nil))
+		})
+	}
+}
+
+func TestVPowerDecodeKey(t *testing.T) {
+	from := btztypes.RandAddress()
+	to := btztypes.RandAddress()
+	item := &VPower{}
+
+	require.NoError(t, item.Decode(v2.LedgerKeyVPower(from, to), nil))
+	require.EqualValues(t, from, item.from)
+	require.EqualValues(t, to, item.to)
+	require.EqualValues(t, v2.LedgerKeyVPower(from, to), item.key)
 }
 
 func randBonding(ctrler *VPowerCtrler) ([]types.ValidatorUpdate, xerrors.XError) {

--- a/ctrlers/vpower/ctrler_vpower.go
+++ b/ctrlers/vpower/ctrler_vpower.go
@@ -4,7 +4,7 @@ import (
 	"encoding/binary"
 
 	types2 "github.com/beatoz/beatoz-go/ctrlers/types"
-	v1 "github.com/beatoz/beatoz-go/ledger/v1"
+	v2 "github.com/beatoz/beatoz-go/ledger/v2"
 	"github.com/beatoz/beatoz-go/types"
 	"github.com/beatoz/beatoz-go/types/bytes"
 	"github.com/beatoz/beatoz-go/types/xerrors"
@@ -12,7 +12,7 @@ import (
 
 func (ctrler *VPowerCtrler) loadDelegatees(exec bool) ([]*Delegatee, xerrors.XError) {
 	var dgtees []*Delegatee
-	xerr := ctrler.vpowerState.Seek(v1.KeyPrefixDelegatee, true, func(key v1.LedgerKey, item v1.ILedgerItem) xerrors.XError {
+	xerr := ctrler.vpowerState.Seek(v2.KeyPrefixDelegatee, true, func(key v2.LedgerKey, item v2.ILedgerItem) xerrors.XError {
 		dgtee, _ := item.(*Delegatee)
 		dgtees = append(dgtees, dgtee)
 		return nil
@@ -25,7 +25,7 @@ func (ctrler *VPowerCtrler) loadDelegatees(exec bool) ([]*Delegatee, xerrors.XEr
 
 func (ctrler *VPowerCtrler) readDelegatee(addr types.Address, exec bool) (*Delegatee, xerrors.XError) {
 	var ret *Delegatee
-	item, xerr := ctrler.vpowerState.Get(v1.LedgerKeyDelegatee(addr), exec)
+	item, xerr := ctrler.vpowerState.Get(v2.LedgerKeyDelegatee(addr), exec)
 	if xerr == nil {
 		ret, _ = item.(*Delegatee)
 	}
@@ -37,12 +37,12 @@ func (ctrler *VPowerCtrler) writeDelegatee(dgtee *Delegatee, exec bool) xerrors.
 }
 
 func (ctrler *VPowerCtrler) removeDelegatee(addr types.Address, exec bool) xerrors.XError {
-	return ctrler.vpowerState.Del(v1.LedgerKeyDelegatee(addr), exec)
+	return ctrler.vpowerState.Del(v2.LedgerKeyDelegatee(addr), exec)
 }
 
 func (ctrler *VPowerCtrler) readVPower(from, to types.Address, exec bool) (*VPower, xerrors.XError) {
 	var ret *VPower
-	item, xerr := ctrler.vpowerState.Get(v1.LedgerKeyVPower(from, to), exec)
+	item, xerr := ctrler.vpowerState.Get(v2.LedgerKeyVPower(from, to), exec)
 	if xerr == nil {
 		ret, _ = item.(*VPower)
 	}
@@ -52,12 +52,12 @@ func (ctrler *VPowerCtrler) writeVPower(vpow *VPower, exec bool) xerrors.XError 
 	return ctrler.vpowerState.Set(vpow.key, vpow, exec)
 }
 
-func (ctrler *VPowerCtrler) seekVPowersOf(from types.Address, cb v1.FuncIterate, exec bool) xerrors.XError {
-	return ctrler.vpowerState.Seek(v1.LedgerKeyVPower(from, nil), true, cb, exec)
+func (ctrler *VPowerCtrler) seekVPowersOf(from types.Address, cb v2.FuncIterate, exec bool) xerrors.XError {
+	return ctrler.vpowerState.Seek(v2.LedgerKeyVPower(from, nil), true, cb, exec)
 }
 
 func (ctrler *VPowerCtrler) removeVPower(from, to types.Address, exec bool) xerrors.XError {
-	return ctrler.vpowerState.Del(v1.LedgerKeyVPower(from, to), exec)
+	return ctrler.vpowerState.Del(v2.LedgerKeyVPower(from, to), exec)
 }
 
 func (ctrler *VPowerCtrler) bondPowerChunk(
@@ -111,7 +111,7 @@ func (ctrler *VPowerCtrler) unbondPowerChunk(dgtee *Delegatee, vpow *VPower, txh
 func (ctrler *VPowerCtrler) freezePowerChunk(from types.Address, pc *PowerChunkProto, refundHeight int64, exec bool) xerrors.XError {
 	// the `from` can do freezing multiple power chunks in one block.
 	// if the `from` already has existing frozen power chunks, add `pc` to them.
-	item, xerr := ctrler.vpowerState.Get(v1.LedgerKeyFrozenVPower(refundHeight, from), exec)
+	item, xerr := ctrler.vpowerState.Get(v2.LedgerKeyFrozenVPower(refundHeight, from), exec)
 	if xerr != nil && xerr != xerrors.ErrNotFoundResult {
 		return xerr
 	}
@@ -123,13 +123,13 @@ func (ctrler *VPowerCtrler) freezePowerChunk(from types.Address, pc *PowerChunkP
 	frozen.RefundPower += pc.Power
 	frozen.PowerChunks = append(frozen.PowerChunks, pc)
 
-	return ctrler.vpowerState.Set(v1.LedgerKeyFrozenVPower(refundHeight, from), frozen, exec)
+	return ctrler.vpowerState.Set(v2.LedgerKeyFrozenVPower(refundHeight, from), frozen, exec)
 }
 
 func (ctrler *VPowerCtrler) freezePowerChunkList(from types.Address, pcs []*PowerChunkProto, refundHeight int64, exec bool) xerrors.XError {
 	// the `from` can do freezing multiple power chunks in one block.
 	// if the `from` already has existing frozen power chunks, add `pcs` to them.
-	item, xerr := ctrler.vpowerState.Get(v1.LedgerKeyFrozenVPower(refundHeight, from), exec)
+	item, xerr := ctrler.vpowerState.Get(v2.LedgerKeyFrozenVPower(refundHeight, from), exec)
 	if xerr != nil && xerr != xerrors.ErrNotFoundResult {
 		return xerr
 	}
@@ -143,7 +143,7 @@ func (ctrler *VPowerCtrler) freezePowerChunkList(from types.Address, pcs []*Powe
 	}
 	frozen.PowerChunks = append(frozen.PowerChunks, pcs...)
 
-	return ctrler.vpowerState.Set(v1.LedgerKeyFrozenVPower(refundHeight, from), frozen, exec)
+	return ctrler.vpowerState.Set(v2.LedgerKeyFrozenVPower(refundHeight, from), frozen, exec)
 }
 
 func (ctrler *VPowerCtrler) unfreezePowerChunk(bctx *types2.BlockContext) xerrors.XError {
@@ -151,7 +151,7 @@ func (ctrler *VPowerCtrler) unfreezePowerChunk(bctx *types2.BlockContext) xerror
 }
 
 func (ctrler *VPowerCtrler) _unfreezePowerChunk(refundHeight int64, acctHandler types2.IAccountHandler) xerrors.XError {
-	var removed []v1.LedgerKey
+	var removed []v2.LedgerKey
 	defer func() {
 		for _, k := range removed {
 			_ = ctrler.vpowerState.Del(k, true)
@@ -159,9 +159,9 @@ func (ctrler *VPowerCtrler) _unfreezePowerChunk(refundHeight int64, acctHandler 
 	}()
 
 	return ctrler.vpowerState.Seek(
-		v1.LedgerKeyFrozenVPower(refundHeight, nil),
+		v2.LedgerKeyFrozenVPower(refundHeight, nil),
 		true,
-		func(key v1.LedgerKey, item v1.ILedgerItem) xerrors.XError {
+		func(key v2.LedgerKey, item v2.ILedgerItem) xerrors.XError {
 			frozen, _ := item.(*FrozenVPower)
 			refundAmt := types.PowerToAmount(frozen.RefundPower)
 
@@ -180,7 +180,7 @@ func (ctrler *VPowerCtrler) _unfreezePowerChunk(refundHeight int64, acctHandler 
 
 func (ctrler *VPowerCtrler) readFrozenVPower(refundHeight int64, from types.Address, exec bool) (*FrozenVPower, xerrors.XError) {
 	var ret *FrozenVPower
-	item, xerr := ctrler.vpowerState.Get(v1.LedgerKeyFrozenVPower(refundHeight, from), exec)
+	item, xerr := ctrler.vpowerState.Get(v2.LedgerKeyFrozenVPower(refundHeight, from), exec)
 	if xerr == nil {
 		ret, _ = item.(*FrozenVPower)
 	}
@@ -188,12 +188,12 @@ func (ctrler *VPowerCtrler) readFrozenVPower(refundHeight int64, from types.Addr
 }
 
 func (ctrler *VPowerCtrler) removeFrozenVPower(refundHeight int64, from types.Address, exec bool) xerrors.XError {
-	return ctrler.vpowerState.Del(v1.LedgerKeyFrozenVPower(refundHeight, from), exec)
+	return ctrler.vpowerState.Del(v2.LedgerKeyFrozenVPower(refundHeight, from), exec)
 }
 
 func (ctrler *VPowerCtrler) countOf(keyPrefix []byte, exec bool) int {
 	ret := 0
-	_ = ctrler.vpowerState.Seek(keyPrefix, true, func(key v1.LedgerKey, item v1.ILedgerItem) xerrors.XError {
+	_ = ctrler.vpowerState.Seek(keyPrefix, true, func(key v2.LedgerKey, item v2.ILedgerItem) xerrors.XError {
 		ret++
 		return nil
 	}, exec)
@@ -224,10 +224,10 @@ func (c *BlockCount) Int64() int64 {
 	return int64(*c)
 }
 
-var _ v1.ILedgerItem = (*BlockCount)(nil)
+var _ v2.ILedgerItem = (*BlockCount)(nil)
 
 func (ctrler *VPowerCtrler) getMissedBlockCount(valAddr types.Address, exec bool) (BlockCount, xerrors.XError) {
-	key := v1.LedgerKeyMissedBlockCount(valAddr)
+	key := v2.LedgerKeyMissedBlockCount(valAddr)
 	d, xerr := ctrler.vpowerState.Get(key, exec)
 	if xerr != nil {
 		return 0, xerr
@@ -237,7 +237,7 @@ func (ctrler *VPowerCtrler) getMissedBlockCount(valAddr types.Address, exec bool
 }
 
 func (ctrler *VPowerCtrler) setMissedBlockCount(valAddr types.Address, c BlockCount, exec bool) xerrors.XError {
-	key := v1.LedgerKeyMissedBlockCount(valAddr)
+	key := v2.LedgerKeyMissedBlockCount(valAddr)
 	return ctrler.vpowerState.Set(key, &c, exec)
 }
 
@@ -253,13 +253,13 @@ func (ctrler *VPowerCtrler) addMissedBlockCount(valAddr types.Address, exec bool
 }
 
 func (ctrler *VPowerCtrler) resetAllMissedBlockCount(exec bool) xerrors.XError {
-	var rmKeys []v1.LedgerKey
+	var rmKeys []v2.LedgerKey
 	defer func() {
 		for _, rmKey := range rmKeys {
 			_ = ctrler.vpowerState.Del(rmKey, exec)
 		}
 	}()
-	return ctrler.vpowerState.Seek(v1.KeyPrefixMissedBlockCount, true, func(key v1.LedgerKey, value v1.ILedgerItem) xerrors.XError {
+	return ctrler.vpowerState.Seek(v2.KeyPrefixMissedBlockCount, true, func(key v2.LedgerKey, value v2.ILedgerItem) xerrors.XError {
 		rmKeys = append(rmKeys, key)
 		return nil
 	}, exec)

--- a/ctrlers/vpower/ctrler_weight.go
+++ b/ctrlers/vpower/ctrler_weight.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 
 	ctrlertypes "github.com/beatoz/beatoz-go/ctrlers/types"
-	v1 "github.com/beatoz/beatoz-go/ledger/v1"
+	v2 "github.com/beatoz/beatoz-go/ledger/v2"
 	"github.com/beatoz/beatoz-go/libs/fxnum"
 	"github.com/beatoz/beatoz-go/types"
 	"github.com/beatoz/beatoz-go/types/bytes"
@@ -36,7 +36,7 @@ func (ctrler *VPowerCtrler) ComputeWeight(
 	for _, val := range lastValidators {
 
 		// NOTE: Consider caching the missed block count.
-		item, xerr := ledger.Get(v1.LedgerKeyMissedBlockCount(val.addr))
+		item, xerr := ledger.Get(v2.LedgerKeyMissedBlockCount(val.addr))
 		if xerr != nil && !xerr.Contains(xerrors.ErrNotFoundResult) {
 			return nil, xerr
 		}
@@ -50,7 +50,7 @@ func (ctrler *VPowerCtrler) ComputeWeight(
 
 		mapBenefPowChunks := make(map[string]*benefPowChunksW)
 		for _, from := range val.Delegators {
-			item, xerr = ledger.Get(v1.LedgerKeyVPower(from, val.addr))
+			item, xerr = ledger.Get(v2.LedgerKeyVPower(from, val.addr))
 			if xerr != nil {
 				return nil, xerr
 			}

--- a/ctrlers/vpower/delegatee.go
+++ b/ctrlers/vpower/delegatee.go
@@ -1,7 +1,7 @@
 package vpower
 
 import (
-	v1 "github.com/beatoz/beatoz-go/ledger/v1"
+	v2 "github.com/beatoz/beatoz-go/ledger/v2"
 	"github.com/beatoz/beatoz-go/types"
 	"github.com/beatoz/beatoz-go/types/bytes"
 	"github.com/beatoz/beatoz-go/types/crypto"
@@ -12,7 +12,7 @@ import (
 
 type Delegatee struct {
 	DelegateeProto
-	key  v1.LedgerKey
+	key  v2.LedgerKey
 	addr types.Address
 }
 
@@ -23,7 +23,7 @@ func NewDelegatee(pubKey bytes.HexBytes) *Delegatee {
 		},
 	}
 	ret.addr = crypto.PubKeyBytes2Addr(pubKey)
-	ret.key = v1.LedgerKeyDelegatee(ret.addr)
+	ret.key = v2.LedgerKeyDelegatee(ret.addr)
 	return ret
 }
 
@@ -44,7 +44,7 @@ func (x *Delegatee) Decode(k, v []byte) xerrors.XError {
 	return nil
 }
 
-var _ v1.ILedgerItem = (*Delegatee)(nil)
+var _ v2.ILedgerItem = (*Delegatee)(nil)
 
 func (x *Delegatee) Address() types.Address {
 	return x.addr

--- a/ctrlers/vpower/vpower.go
+++ b/ctrlers/vpower/vpower.go
@@ -2,7 +2,7 @@ package vpower
 
 import (
 	"fmt"
-	"github.com/beatoz/beatoz-go/ledger/v1"
+	"github.com/beatoz/beatoz-go/ledger/v2"
 	"github.com/beatoz/beatoz-go/types"
 	"github.com/beatoz/beatoz-go/types/bytes"
 	"github.com/beatoz/beatoz-go/types/xerrors"
@@ -11,7 +11,7 @@ import (
 
 type VPower struct {
 	VPowerProto
-	key  v1.LedgerKey
+	key  v2.LedgerKey
 	from types.Address
 	to   types.Address
 }
@@ -20,7 +20,7 @@ func NewVPower(from types.Address, to types.Address) *VPower {
 	ret := &VPower{}
 	ret.from = from
 	ret.to = to
-	ret.key = v1.LedgerKeyVPower(ret.from, ret.to)
+	ret.key = v2.LedgerKeyVPower(ret.from, ret.to)
 	return ret
 }
 
@@ -37,14 +37,18 @@ func (x *VPower) Decode(k, v []byte) xerrors.XError {
 		return xerrors.From(err)
 	}
 	// k is `prefix + from_address + to_address`
+	expectedKeyLen := len(v2.KeyPrefixVPower) + types.AddrSize*2
+	if len(k) != expectedKeyLen {
+		return xerrors.NewOrdinary("invalid vpower ledger key length")
+	}
 	x.key = k
-	from_to := v1.UnwrapKeyPrefix(k)
+	from_to := v2.UnwrapKeyPrefix(k)
 	x.from = from_to[:20]
 	x.to = from_to[20:]
 	return nil
 }
 
-var _ v1.ILedgerItem = (*VPower)(nil)
+var _ v2.ILedgerItem = (*VPower)(nil)
 
 func (x *VPower) IsSelfPower() bool {
 	return bytes.Equal(x.from, x.to)

--- a/ctrlers/vpower/vpower_frozen.go
+++ b/ctrlers/vpower/vpower_frozen.go
@@ -1,7 +1,7 @@
 package vpower
 
 import (
-	v1 "github.com/beatoz/beatoz-go/ledger/v1"
+	v2 "github.com/beatoz/beatoz-go/ledger/v2"
 	"github.com/beatoz/beatoz-go/types/xerrors"
 	"google.golang.org/protobuf/proto"
 )
@@ -41,4 +41,4 @@ func (x *FrozenVPower) appendPowerChunks(powChunks ...*PowerChunkProto) {
 	}
 }
 
-var _ v1.ILedgerItem = (*FrozenVPower)(nil)
+var _ v2.ILedgerItem = (*FrozenVPower)(nil)

--- a/ledger/v2/cache_context.go
+++ b/ledger/v2/cache_context.go
@@ -1,0 +1,119 @@
+package v2
+
+import "github.com/beatoz/beatoz-go/types/xerrors"
+
+type cacheStore interface {
+	getRaw(key []byte) ([]byte, bool, xerrors.XError)
+	setRaw(key, value []byte) xerrors.XError
+	deleteRaw(key []byte) xerrors.XError
+}
+
+type cacheContext struct {
+	parent cacheStore
+	writes *writeSet
+}
+
+func newCacheContext(parent cacheStore) *cacheContext {
+	return &cacheContext{
+		parent: parent,
+		writes: newWriteSet(),
+	}
+}
+
+func (ctx *cacheContext) CacheWrap() *cacheContext {
+	return newCacheContext(ctx)
+}
+
+func (ctx *cacheContext) parentMissing() bool {
+	return ctx.parent == nil
+}
+
+func (ctx *cacheContext) Write() xerrors.XError {
+	if ctx.parentMissing() {
+		return xerrors.NewOrdinary("cache context parent is nil")
+	}
+	for _, entry := range ctx.dirtyEntries(true) {
+		switch entry.op {
+		case opSet:
+			if xerr := ctx.parent.setRaw(entry.key, entry.val); xerr != nil {
+				return xerr
+			}
+		case opDel:
+			if xerr := ctx.parent.deleteRaw(entry.key); xerr != nil {
+				return xerr
+			}
+		}
+	}
+	ctx.writes.reset()
+	return nil
+}
+
+func (ctx *cacheContext) Get(key []byte) ([]byte, bool, xerrors.XError) {
+	if entry, ok := ctx.writes.get(key); ok {
+		return entry.value()
+	}
+	if ctx.parentMissing() {
+		return nil, false, xerrors.NewOrdinary("cache context parent is nil")
+	}
+	return ctx.parent.getRaw(key)
+}
+
+func (ctx *cacheContext) Set(key, val []byte) xerrors.XError {
+	ctx.writes.set(key, val)
+	return nil
+}
+
+func (ctx *cacheContext) Delete(key []byte) xerrors.XError {
+	ctx.writes.del(key)
+	return nil
+}
+
+func (ctx *cacheContext) dirtyEntries(ascending bool) []*writeEntry {
+	return ctx.writes.orderedEntries(ascending)
+}
+
+func (ctx *cacheContext) keysWithPrefix(prefix []byte) [][]byte {
+	return ctx.writes.keysWithPrefix(prefix)
+}
+
+func (ctx *cacheContext) keysWithPrefixDeep(prefix []byte) [][]byte {
+	keys := make(map[string][]byte)
+	ctx.collectKeysWithPrefix(prefix, keys)
+
+	ret := make([][]byte, 0, len(keys))
+	for _, key := range keys {
+		ret = append(ret, cloneBytes(key))
+	}
+	sortLedgerKeys(ret, true)
+	return ret
+}
+
+func (ctx *cacheContext) collectKeysWithPrefix(prefix []byte, keys map[string][]byte) {
+	if parent, ok := ctx.parent.(*cacheContext); ok {
+		parent.collectKeysWithPrefix(prefix, keys)
+	}
+	for _, key := range ctx.keysWithPrefix(prefix) {
+		keys[string(key)] = cloneBytes(key)
+	}
+}
+
+func (ctx *cacheContext) getRaw(key []byte) ([]byte, bool, xerrors.XError) {
+	return ctx.Get(key)
+}
+
+func (ctx *cacheContext) setRaw(key, value []byte) xerrors.XError {
+	return ctx.Set(key, value)
+}
+
+func (ctx *cacheContext) deleteRaw(key []byte) xerrors.XError {
+	return ctx.Delete(key)
+}
+
+func (entry *writeEntry) value() ([]byte, bool, xerrors.XError) {
+	if entry.op == opDel {
+		return nil, false, nil
+	}
+	return cloneBytes(entry.val), true, nil
+}
+
+var _ cacheStore = (*cacheContext)(nil)

--- a/ledger/v2/cache_context_test.go
+++ b/ledger/v2/cache_context_test.go
@@ -1,0 +1,191 @@
+package v2
+
+import (
+	"testing"
+
+	"github.com/beatoz/beatoz-go/types/xerrors"
+	"github.com/stretchr/testify/require"
+)
+
+type memoryCacheParent struct {
+	values map[string][]byte
+}
+
+func newMemoryCacheParent() *memoryCacheParent {
+	return &memoryCacheParent{
+		values: make(map[string][]byte),
+	}
+}
+
+func (parent *memoryCacheParent) getRaw(key []byte) ([]byte, bool, xerrors.XError) {
+	val, ok := parent.values[string(key)]
+	if !ok {
+		return nil, false, nil
+	}
+	return cloneBytes(val), true, nil
+}
+
+func (parent *memoryCacheParent) setRaw(key, value []byte) xerrors.XError {
+	parent.values[string(key)] = cloneBytes(value)
+	return nil
+}
+
+func (parent *memoryCacheParent) deleteRaw(key []byte) xerrors.XError {
+	delete(parent.values, string(key))
+	return nil
+}
+
+func TestCacheContextReadThroughParent(t *testing.T) {
+	parent := newMemoryCacheParent()
+	require.NoError(t, parent.setRaw([]byte{0x01}, []byte("parent")))
+	ctx := newCacheContext(parent)
+
+	val, ok, xerr := ctx.Get([]byte{0x01})
+	require.NoError(t, xerr)
+	require.True(t, ok)
+	require.Equal(t, []byte("parent"), val)
+}
+
+func TestCacheContextSetAndDeleteStayLocalUntilWrite(t *testing.T) {
+	parent := newMemoryCacheParent()
+	ctx := newCacheContext(parent)
+
+	require.NoError(t, ctx.Set([]byte{0x01}, []byte("local")))
+	val, ok, xerr := ctx.Get([]byte{0x01})
+	require.NoError(t, xerr)
+	require.True(t, ok)
+	require.Equal(t, []byte("local"), val)
+
+	_, ok, xerr = parent.getRaw([]byte{0x01})
+	require.NoError(t, xerr)
+	require.False(t, ok)
+
+	require.NoError(t, ctx.Delete([]byte{0x01}))
+	_, ok, xerr = ctx.Get([]byte{0x01})
+	require.NoError(t, xerr)
+	require.False(t, ok)
+}
+
+func TestCacheContextWriteFlushesDirtyEntriesToParent(t *testing.T) {
+	parent := newMemoryCacheParent()
+	require.NoError(t, parent.setRaw([]byte{0x01}, []byte("old")))
+	ctx := newCacheContext(parent)
+
+	require.NoError(t, ctx.Set([]byte{0x01}, []byte("new")))
+	require.NoError(t, ctx.Set([]byte{0x02}, []byte("created")))
+	require.NoError(t, ctx.Delete([]byte{0x03}))
+	require.NoError(t, ctx.Write())
+
+	val, ok, xerr := parent.getRaw([]byte{0x01})
+	require.NoError(t, xerr)
+	require.True(t, ok)
+	require.Equal(t, []byte("new"), val)
+
+	val, ok, xerr = parent.getRaw([]byte{0x02})
+	require.NoError(t, xerr)
+	require.True(t, ok)
+	require.Equal(t, []byte("created"), val)
+	require.Empty(t, ctx.dirtyEntries(true))
+}
+
+func TestCacheContextCacheWrapWritePromotesToParentCache(t *testing.T) {
+	root := newMemoryCacheParent()
+	blockCache := newCacheContext(root)
+	txCache := blockCache.CacheWrap()
+
+	require.NoError(t, txCache.Set([]byte{0x01}, []byte("tx")))
+
+	_, ok, xerr := blockCache.Get([]byte{0x01})
+	require.NoError(t, xerr)
+	require.False(t, ok)
+
+	require.NoError(t, txCache.Write())
+
+	val, ok, xerr := blockCache.Get([]byte{0x01})
+	require.NoError(t, xerr)
+	require.True(t, ok)
+	require.Equal(t, []byte("tx"), val)
+
+	_, ok, xerr = root.getRaw([]byte{0x01})
+	require.NoError(t, xerr)
+	require.False(t, ok)
+}
+
+func TestCacheContextDiscardedChildDoesNotAffectParent(t *testing.T) {
+	root := newMemoryCacheParent()
+	blockCache := newCacheContext(root)
+	txCache := blockCache.CacheWrap()
+
+	require.NoError(t, txCache.Set([]byte{0x01}, []byte("tx")))
+	txCache = nil
+
+	_, ok, xerr := blockCache.Get([]byte{0x01})
+	require.NoError(t, xerr)
+	require.False(t, ok)
+	require.Nil(t, txCache)
+}
+
+func TestCacheContextLastWriteWins(t *testing.T) {
+	parent := newMemoryCacheParent()
+	ctx := newCacheContext(parent)
+
+	require.NoError(t, ctx.Set([]byte{0x01}, []byte("first")))
+	require.NoError(t, ctx.Delete([]byte{0x01}))
+	require.NoError(t, ctx.Set([]byte{0x01}, []byte("second")))
+	require.NoError(t, ctx.Write())
+
+	val, ok, xerr := parent.getRaw([]byte{0x01})
+	require.NoError(t, xerr)
+	require.True(t, ok)
+	require.Equal(t, []byte("second"), val)
+}
+
+func TestCacheContextDirtyEntriesAreDeterministic(t *testing.T) {
+	ctx := newCacheContext(newMemoryCacheParent())
+
+	require.NoError(t, ctx.Set([]byte{0x02}, []byte("2")))
+	require.NoError(t, ctx.Set([]byte{0x01}, []byte("1")))
+	require.NoError(t, ctx.Delete([]byte{0x03}))
+
+	ascending := ctx.dirtyEntries(true)
+	require.Equal(t, []byte{0x01}, ascending[0].key)
+	require.Equal(t, []byte{0x02}, ascending[1].key)
+	require.Equal(t, []byte{0x03}, ascending[2].key)
+
+	descending := ctx.dirtyEntries(false)
+	require.Equal(t, []byte{0x03}, descending[0].key)
+	require.Equal(t, []byte{0x02}, descending[1].key)
+	require.Equal(t, []byte{0x01}, descending[2].key)
+}
+
+func TestCacheContextKeysWithPrefix(t *testing.T) {
+	ctx := newCacheContext(newMemoryCacheParent())
+	require.NoError(t, ctx.Set([]byte{0x10, 0x02}, []byte("2")))
+	require.NoError(t, ctx.Set([]byte{0x10, 0x01}, []byte("1")))
+	require.NoError(t, ctx.Set([]byte{0x11, 0x01}, []byte("other")))
+
+	keys := ctx.keysWithPrefix([]byte{0x10})
+	require.Equal(t, [][]byte{
+		{0x10, 0x01},
+		{0x10, 0x02},
+	}, keys)
+}
+
+func TestCacheContextNilParent(t *testing.T) {
+	ctx := newCacheContext(nil)
+
+	require.NotPanics(t, func() {
+		_, _, xerr := ctx.Get([]byte{0x01})
+		require.Error(t, xerr)
+	})
+	require.NoError(t, ctx.Set([]byte{0x01}, []byte("local")))
+
+	val, ok, xerr := ctx.Get([]byte{0x01})
+	require.NoError(t, xerr)
+	require.True(t, ok)
+	require.Equal(t, []byte("local"), val)
+
+	require.NotPanics(t, func() {
+		require.Error(t, ctx.Write())
+	})
+}

--- a/ledger/v2/ledger_keys.go
+++ b/ledger/v2/ledger_keys.go
@@ -1,0 +1,85 @@
+package v2
+
+import (
+	"encoding/binary"
+
+	"github.com/beatoz/beatoz-go/types"
+)
+
+var (
+	KeyPrefixAccount          = []byte{0x00}
+	KeyPrefixGovParams        = []byte{0x10}
+	KeyPrefixProposal         = []byte{0x11}
+	KeyPrefixFrozenProp       = []byte{0x12}
+	KeyPrefixDelegatee        = []byte{0x20}
+	KeyPrefixVPower           = []byte{0x21}
+	KeyPrefixFrozenVPower     = []byte{0x22}
+	KeyPrefixMissedBlockCount = []byte{0x23}
+	KeyPrefixTotalSupply      = []byte{0x30}
+	KeyPrefixReward           = []byte{0x32}
+)
+
+func LedgerKeyProposal(txhash []byte) LedgerKey {
+	_key := make([]byte, len(KeyPrefixProposal)+len(txhash))
+	copy(_key, append(KeyPrefixProposal, txhash...))
+	return _key
+}
+
+func LedgerKeyFrozenProp(txhash []byte) LedgerKey {
+	_key := make([]byte, len(KeyPrefixFrozenProp)+len(txhash))
+	copy(_key, append(KeyPrefixFrozenProp, txhash...))
+	return _key
+}
+
+func LedgerKeyAccount(addr types.Address) LedgerKey {
+	key := make([]byte, len(KeyPrefixAccount)+len(addr))
+	copy(key, append(KeyPrefixAccount, addr...))
+	return key
+}
+
+func LedgerKeyGovParams() LedgerKey {
+	_key := make([]byte, len(KeyPrefixGovParams))
+	copy(_key, KeyPrefixGovParams)
+	return _key
+}
+
+func LedgerKeyVPower(from, to types.Address) LedgerKey {
+	k := make([]byte, len(KeyPrefixVPower)+len(from)+len(to))
+	copy(k, KeyPrefixVPower)
+	copy(k[len(KeyPrefixVPower):], append(from, to...))
+	return k
+}
+
+func LedgerKeyDelegatee(addr types.Address) LedgerKey {
+	k := make([]byte, len(KeyPrefixDelegatee)+len(addr))
+	copy(k, KeyPrefixDelegatee)
+	copy(k[len(KeyPrefixDelegatee):], addr)
+	return k
+}
+
+func LedgerKeyFrozenVPower(h int64, from types.Address) LedgerKey {
+	k := make([]byte, len(KeyPrefixFrozenVPower)+8+len(from))
+	copy(k, KeyPrefixFrozenVPower)
+	binary.BigEndian.PutUint64(k[len(KeyPrefixFrozenVPower):], uint64(h))
+	copy(k[len(KeyPrefixFrozenVPower)+8:], from)
+	return k
+}
+
+func LedgerKeyMissedBlockCount(signer types.Address) LedgerKey {
+	k := make([]byte, len(KeyPrefixMissedBlockCount)+len(signer))
+	copy(k, KeyPrefixMissedBlockCount)
+	copy(k[len(KeyPrefixMissedBlockCount):], signer)
+	return k
+}
+
+func LedgerKeyTotalSupply() LedgerKey {
+	return append(KeyPrefixTotalSupply, []byte("supply")...)
+}
+
+func LedgerKeyReward(owner types.Address) LedgerKey {
+	return append(KeyPrefixReward, owner...)
+}
+
+func UnwrapKeyPrefix(key LedgerKey) []byte {
+	return key[1:]
+}

--- a/ledger/v2/mem_ledger.go
+++ b/ledger/v2/mem_ledger.go
@@ -1,0 +1,229 @@
+package v2
+
+import (
+	"bytes"
+	"sort"
+	"sync"
+
+	"github.com/beatoz/beatoz-go/types/xerrors"
+	"github.com/cosmos/iavl"
+	tmlog "github.com/tendermint/tendermint/libs/log"
+)
+
+type immutableTreeStore struct {
+	tree *iavl.ImmutableTree
+}
+
+func (store *immutableTreeStore) getRaw(key []byte) ([]byte, bool, xerrors.XError) {
+	if store == nil || store.tree == nil {
+		return nil, false, nil
+	}
+	bz, err := store.tree.Get(key)
+	if err != nil {
+		return nil, false, xerrors.From(err)
+	}
+	if bz == nil {
+		return nil, false, nil
+	}
+	return cloneBytes(bz), true, nil
+}
+
+func (store *immutableTreeStore) setRaw(_, _ []byte) xerrors.XError {
+	return xerrors.NewOrdinary("immutable tree store is read-only")
+}
+
+func (store *immutableTreeStore) deleteRaw(_ []byte) xerrors.XError {
+	return xerrors.NewOrdinary("immutable tree store is read-only")
+}
+
+type MemLedger struct {
+	immuTree   *iavl.ImmutableTree
+	cache      *cacheContext
+	newItemFor FuncNewItemFor
+	logger     tmlog.Logger
+	mtx        sync.RWMutex
+}
+
+var _ IImitable = (*MemLedger)(nil)
+
+func NewMemLedgerAt(ver int64, from IMutable, lg tmlog.Logger) (*MemLedger, xerrors.XError) {
+	var tree *iavl.ImmutableTree
+	if ver > 0 {
+		_tree, xerr := from.GetReadOnlyTree(ver)
+		if xerr != nil {
+			return nil, xerr
+		}
+		tree = _tree
+	}
+
+	return newMemLedger(tree, newCacheContext(&immutableTreeStore{tree: tree}), from.NewItem, lg), nil
+}
+
+func newMemLedger(tree *iavl.ImmutableTree, cache *cacheContext, newItem FuncNewItemFor, lg tmlog.Logger) *MemLedger {
+	return &MemLedger{
+		immuTree:   tree,
+		cache:      cache,
+		newItemFor: newItem,
+		logger:     lg.With("ledger", "MemLedger"),
+	}
+}
+
+func (ledger *MemLedger) closed() bool {
+	return ledger.cache == nil
+}
+
+func (ledger *MemLedger) CacheWrap() *MemLedger {
+	ledger.mtx.RLock()
+	defer ledger.mtx.RUnlock()
+
+	if ledger.closed() {
+		return nil
+	}
+	return newMemLedger(ledger.immuTree, ledger.cache.CacheWrap(), ledger.newItemFor, ledger.logger)
+}
+
+func (ledger *MemLedger) Write() xerrors.XError {
+	ledger.mtx.Lock()
+	defer ledger.mtx.Unlock()
+
+	if ledger.closed() {
+		return xerrors.NewOrdinary("mem ledger is closed")
+	}
+	return ledger.cache.Write()
+}
+
+func (ledger *MemLedger) Get(key LedgerKey) (ILedgerItem, xerrors.XError) {
+	ledger.mtx.RLock()
+	defer ledger.mtx.RUnlock()
+
+	if ledger.closed() {
+		return nil, xerrors.NewOrdinary("mem ledger is closed")
+	}
+	bz, ok, xerr := ledger.cache.Get(key)
+	if xerr != nil {
+		return nil, xerr
+	}
+	if !ok {
+		return nil, xerrors.ErrNotFoundResult
+	}
+
+	item := ledger.newItemFor(key)
+	if item == nil {
+		return nil, xerrors.NewOrdinary("mem ledger item factory returned nil")
+	}
+	if xerr := item.Decode(key, bz); xerr != nil {
+		return nil, xerr
+	}
+	return item, nil
+}
+
+func (ledger *MemLedger) Set(key LedgerKey, item ILedgerItem) xerrors.XError {
+	ledger.mtx.Lock()
+	defer ledger.mtx.Unlock()
+
+	if ledger.closed() {
+		return xerrors.NewOrdinary("mem ledger is closed")
+	}
+	if item == nil {
+		return xerrors.NewOrdinary("mem ledger item is nil")
+	}
+	bz, xerr := item.Encode()
+	if xerr != nil {
+		return xerr
+	}
+	return ledger.cache.Set(key, bz)
+}
+
+func (ledger *MemLedger) Del(key LedgerKey) xerrors.XError {
+	ledger.mtx.Lock()
+	defer ledger.mtx.Unlock()
+
+	if ledger.closed() {
+		return xerrors.NewOrdinary("mem ledger is closed")
+	}
+	return ledger.cache.Delete(key)
+}
+
+func (ledger *MemLedger) Iterate(cb FuncIterate) xerrors.XError {
+	return ledger.Seek(nil, true, cb)
+}
+
+func (ledger *MemLedger) Seek(prefix []byte, ascending bool, cb FuncIterate) xerrors.XError {
+	ledger.mtx.RLock()
+	defer ledger.mtx.RUnlock()
+
+	if ledger.closed() {
+		return xerrors.NewOrdinary("mem ledger is closed")
+	}
+	if cb == nil {
+		return xerrors.NewOrdinary("mem ledger iterator callback is nil")
+	}
+	keys, xerr := ledger.seekKeys(prefix, ascending)
+	if xerr != nil {
+		return xerr
+	}
+
+	for _, key := range keys {
+		bz, ok, xerr := ledger.cache.Get(key)
+		if xerr != nil {
+			return xerr
+		}
+		if !ok {
+			continue
+		}
+
+		item := ledger.newItemFor(key)
+		if item == nil {
+			return xerrors.NewOrdinary("mem ledger item factory returned nil")
+		}
+		if xerr := item.Decode(key, bz); xerr != nil {
+			return xerr
+		}
+		if xerr := cb(key, item); xerr != nil {
+			return xerr
+		}
+	}
+	return nil
+}
+
+func (ledger *MemLedger) seekKeys(prefix []byte, ascending bool) ([][]byte, xerrors.XError) {
+	keys := make(map[string][]byte)
+	if ledger.immuTree != nil {
+		iter, err := ledger.immuTree.Iterator(prefix, nil, true)
+		if err != nil {
+			return nil, xerrors.From(err)
+		}
+		defer func() {
+			_ = iter.Close()
+		}()
+
+		for ; iter.Valid(); iter.Next() {
+			key := iter.Key()
+			if !bytes.HasPrefix(key, prefix) {
+				break
+			}
+			keys[string(key)] = cloneBytes(key)
+		}
+	}
+
+	for _, key := range ledger.cache.keysWithPrefixDeep(prefix) {
+		keys[string(key)] = cloneBytes(key)
+	}
+
+	ret := make([][]byte, 0, len(keys))
+	for _, key := range keys {
+		ret = append(ret, key)
+	}
+	sortLedgerKeys(ret, ascending)
+	return ret, nil
+}
+
+func sortLedgerKeys(keys [][]byte, ascending bool) {
+	sort.Slice(keys, func(i, j int) bool {
+		cmp := bytes.Compare(keys[i], keys[j])
+		if ascending {
+			return cmp < 0
+		}
+		return cmp > 0
+	})
+}

--- a/ledger/v2/mem_ledger_test.go
+++ b/ledger/v2/mem_ledger_test.go
@@ -1,0 +1,238 @@
+package v2
+
+import (
+	"encoding/binary"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/beatoz/beatoz-go/types/xerrors"
+	"github.com/cosmos/iavl"
+	dbm "github.com/cosmos/iavl/db"
+	"github.com/stretchr/testify/require"
+	"github.com/tendermint/tendermint/libs/log"
+)
+
+func TestMemLedgerCacheWrite(t *testing.T) {
+	ledger := newMemLedgerForTest(t)
+
+	child := ledger.CacheWrap()
+	require.NoError(t, child.Set(testLedgerKey(2), newTestLedgerItem(2, "child")))
+
+	_, xerr := ledger.Get(testLedgerKey(2))
+	require.Error(t, xerr)
+	require.True(t, xerr.Contains(xerrors.ErrNotFoundResult))
+
+	require.NoError(t, child.Write())
+	item, xerr := ledger.Get(testLedgerKey(2))
+	require.NoError(t, xerr)
+	require.Equal(t, "child", item.(*testLedgerItem).data)
+}
+
+func TestMemLedgerCacheDiscard(t *testing.T) {
+	ledger := newMemLedgerForTest(t)
+
+	child := ledger.CacheWrap()
+	require.NoError(t, child.Set(testLedgerKey(2), newTestLedgerItem(2, "child")))
+	child = nil
+
+	_, xerr := ledger.Get(testLedgerKey(2))
+	require.Error(t, xerr)
+	require.True(t, xerr.Contains(xerrors.ErrNotFoundResult))
+	require.Nil(t, child)
+}
+
+func TestMemLedgerSetDel(t *testing.T) {
+	ledger := newMemLedgerForTest(t)
+
+	require.NoError(t, ledger.Set(testLedgerKey(2), newTestLedgerItem(2, "two")))
+	require.NoError(t, ledger.Del(testLedgerKey(2)))
+
+	_, xerr := ledger.Get(testLedgerKey(2))
+	require.Error(t, xerr)
+	require.True(t, xerr.Contains(xerrors.ErrNotFoundResult))
+}
+
+func TestMemLedgerParentKept(t *testing.T) {
+	ledger := newMemLedgerForTest(t)
+
+	child := ledger.CacheWrap()
+	require.NoError(t, child.Set(testLedgerKey(2), newTestLedgerItem(2, "child")))
+	require.NoError(t, child.Del(testLedgerKey(1)))
+	child = nil
+
+	item, xerr := ledger.Get(testLedgerKey(1))
+	require.NoError(t, xerr)
+	require.Equal(t, "one", item.(*testLedgerItem).data)
+
+	_, xerr = ledger.Get(testLedgerKey(2))
+	require.Error(t, xerr)
+	require.True(t, xerr.Contains(xerrors.ErrNotFoundResult))
+	require.Nil(t, child)
+}
+
+func TestMemLedgerGetCopy(t *testing.T) {
+	ledger := newMemLedgerForTest(t)
+
+	item, xerr := ledger.Get(testLedgerKey(1))
+	require.NoError(t, xerr)
+	item.(*testLedgerItem).data = "mutated"
+
+	item, xerr = ledger.Get(testLedgerKey(1))
+	require.NoError(t, xerr)
+	require.Equal(t, "one", item.(*testLedgerItem).data)
+}
+
+func TestMemLedgerDeleteShadow(t *testing.T) {
+	ledger := newMemLedgerForTest(t)
+
+	child := ledger.CacheWrap()
+	require.NoError(t, child.Del(testLedgerKey(1)))
+
+	item, xerr := ledger.Get(testLedgerKey(1))
+	require.NoError(t, xerr)
+	require.Equal(t, "one", item.(*testLedgerItem).data)
+
+	_, xerr = child.Get(testLedgerKey(1))
+	require.Error(t, xerr)
+	require.True(t, xerr.Contains(xerrors.ErrNotFoundResult))
+
+	require.NoError(t, child.Write())
+	_, xerr = ledger.Get(testLedgerKey(1))
+	require.Error(t, xerr)
+	require.True(t, xerr.Contains(xerrors.ErrNotFoundResult))
+}
+
+func TestMemLedgerSeekOverlay(t *testing.T) {
+	ledger := newMemLedgerForTest(t)
+
+	require.NoError(t, ledger.Set(testLedgerKey(2), newTestLedgerItem(2, "two")))
+	require.NoError(t, ledger.Del(testLedgerKey(3)))
+
+	var got []string
+	xerr := ledger.Seek(nil, true, func(_ LedgerKey, item ILedgerItem) xerrors.XError {
+		got = append(got, item.(*testLedgerItem).data)
+		return nil
+	})
+	require.NoError(t, xerr)
+	require.Equal(t, []string{"one", "two"}, got)
+}
+
+func TestMemLedgerSeekDesc(t *testing.T) {
+	ledger := newMemLedgerForTest(t)
+	require.NoError(t, ledger.Set(testLedgerKey(2), newTestLedgerItem(2, "two")))
+
+	var got []int
+	xerr := ledger.Seek(nil, false, func(key LedgerKey, _ ILedgerItem) xerrors.XError {
+		got = append(got, int(binary.BigEndian.Uint32(key)))
+		return nil
+	})
+	require.NoError(t, xerr)
+	require.Equal(t, []int{3, 2, 1}, got)
+}
+
+func TestMemLedgerGuards(t *testing.T) {
+	ledger := newMemLedgerForTest(t)
+
+	require.NotPanics(t, func() {
+		require.Error(t, ledger.Set(testLedgerKey(1), nil))
+	})
+	require.NotPanics(t, func() {
+		require.Error(t, ledger.Seek(nil, true, nil))
+	})
+
+	require.NoError(t, ledger.Set(testLedgerKey(2), newTestLedgerItem(2, "two")))
+	ledger.newItemFor = func(LedgerKey) ILedgerItem {
+		return nil
+	}
+	require.NotPanics(t, func() {
+		_, xerr := ledger.Get(testLedgerKey(2))
+		require.Error(t, xerr)
+	})
+
+	ledger.cache = nil
+	require.Nil(t, ledger.CacheWrap())
+	require.NotPanics(t, func() {
+		_, xerr := ledger.Get(testLedgerKey(1))
+		require.Error(t, xerr)
+	})
+	require.Error(t, ledger.Write())
+	require.Error(t, ledger.Set(testLedgerKey(1), newTestLedgerItem(1, "one")))
+	require.Error(t, ledger.Del(testLedgerKey(1)))
+	require.Error(t, ledger.Seek(nil, true, func(LedgerKey, ILedgerItem) xerrors.XError {
+		return nil
+	}))
+}
+
+func newMemLedgerForTest(t *testing.T) *MemLedger {
+	t.Helper()
+
+	tree := newImmutableTreeForTest(t,
+		newTestLedgerItem(1, "one"),
+		newTestLedgerItem(3, "three"),
+	)
+	return newMemLedger(tree, newCacheContext(&immutableTreeStore{tree: tree}), func(LedgerKey) ILedgerItem {
+		return &testLedgerItem{}
+	}, log.NewNopLogger())
+}
+
+func newImmutableTreeForTest(t *testing.T, items ...*testLedgerItem) *iavl.ImmutableTree {
+	t.Helper()
+
+	mtree := iavl.NewMutableTree(dbm.NewMemDB(), 100, false, iavl.NewNopLogger())
+	for _, item := range items {
+		bz, xerr := item.Encode()
+		require.NoError(t, xerr)
+		_, err := mtree.Set(item.Key(), bz)
+		require.NoError(t, err)
+	}
+	_, version, err := mtree.SaveVersion()
+	require.NoError(t, err)
+
+	itree, err := mtree.GetImmutable(version)
+	require.NoError(t, err)
+	return itree
+}
+
+type testLedgerItem struct {
+	key  int
+	data string
+}
+
+func newTestLedgerItem(key int, data string) *testLedgerItem {
+	return &testLedgerItem{
+		key:  key,
+		data: data,
+	}
+}
+
+func (item *testLedgerItem) Key() LedgerKey {
+	return testLedgerKey(item.key)
+}
+
+func testLedgerKey(key int) LedgerKey {
+	bz := make([]byte, 4)
+	binary.BigEndian.PutUint32(bz, uint32(key))
+	return bz
+}
+
+func (item *testLedgerItem) Encode() ([]byte, xerrors.XError) {
+	return []byte(fmt.Sprintf("key:%d,data:%s", item.key, item.data)), nil
+}
+
+func (item *testLedgerItem) Decode(_, value []byte) xerrors.XError {
+	parts := strings.Split(string(value), ",")
+	key, _ := strings.CutPrefix(parts[0], "key:")
+	data, _ := strings.CutPrefix(parts[1], "data:")
+
+	i, err := strconv.Atoi(key)
+	if err != nil {
+		return xerrors.From(err)
+	}
+	item.key = i
+	item.data = data
+	return nil
+}
+
+var _ ILedgerItem = (*testLedgerItem)(nil)

--- a/ledger/v2/mutable_ledger.go
+++ b/ledger/v2/mutable_ledger.go
@@ -1,0 +1,310 @@
+package v2
+
+import (
+	"bytes"
+	"sync"
+
+	"github.com/beatoz/beatoz-go/types/xerrors"
+	"github.com/cosmos/iavl"
+	dbm "github.com/cosmos/iavl/db"
+	tmlog "github.com/tendermint/tendermint/libs/log"
+)
+
+type mutableTreeStore struct {
+	tree *iavl.MutableTree
+}
+
+func (store *mutableTreeStore) getRaw(key []byte) ([]byte, bool, xerrors.XError) {
+	if store == nil || store.tree == nil {
+		return nil, false, nil
+	}
+	// bz is the raw encoded ledger item value stored in the IAVL tree.
+	bz, err := store.tree.Get(key)
+	if err != nil {
+		return nil, false, xerrors.From(err)
+	}
+	if bz == nil {
+		return nil, false, nil
+	}
+	return cloneBytes(bz), true, nil
+}
+
+func (store *mutableTreeStore) setRaw(key, value []byte) xerrors.XError {
+	if _, err := store.tree.Set(key, value); err != nil {
+		return xerrors.From(err)
+	}
+	return nil
+}
+
+func (store *mutableTreeStore) deleteRaw(key []byte) xerrors.XError {
+	if _, _, err := store.tree.Remove(key); err != nil {
+		return xerrors.From(err)
+	}
+	return nil
+}
+
+type MutableLedger struct {
+	db    dbm.DB
+	tree  *iavl.MutableTree
+	cache *cacheContext
+
+	newItemFor FuncNewItemFor
+	cacheSize  int
+
+	logger tmlog.Logger
+	mtx    sync.RWMutex
+}
+
+var _ IMutable = (*MutableLedger)(nil)
+
+func NewMutableLedger(name, dbDir string, cacheSize int, newItem FuncNewItemFor, lg tmlog.Logger) (*MutableLedger, xerrors.XError) {
+	db, err := dbm.NewGoLevelDB(name, dbDir)
+	if err != nil {
+		return nil, xerrors.Wrap(err, "goleveldb open failed")
+	}
+
+	tree := iavl.NewMutableTree(db, cacheSize, false, iavl.NewNopLogger(), iavl.SyncOption(true))
+	if _, err := tree.LoadVersion(0); err != nil {
+		_ = tree.Close()
+		_ = db.Close()
+		return nil, xerrors.Wrap(err, "tree's LoadVersion failed")
+	}
+
+	return newMutableLedger(db, tree, newCacheContext(&mutableTreeStore{tree: tree}), cacheSize, newItem, lg), nil
+}
+
+func newMutableLedger(db dbm.DB, tree *iavl.MutableTree, cache *cacheContext, cacheSize int, newItem FuncNewItemFor, lg tmlog.Logger) *MutableLedger {
+	return &MutableLedger{
+		db:         db,
+		tree:       tree,
+		cache:      cache,
+		newItemFor: newItem,
+		cacheSize:  cacheSize,
+		logger:     lg.With("ledger", "MutableLedger"),
+	}
+}
+
+func (ledger *MutableLedger) closed() bool {
+	return ledger.tree == nil || ledger.cache == nil
+}
+
+func (ledger *MutableLedger) CacheWrap() *MutableLedger {
+	ledger.mtx.RLock()
+	defer ledger.mtx.RUnlock()
+
+	if ledger.closed() {
+		return nil
+	}
+	return newMutableLedger(ledger.db, ledger.tree, ledger.cache.CacheWrap(), ledger.cacheSize, ledger.newItemFor, ledger.logger)
+}
+
+func (ledger *MutableLedger) Write() xerrors.XError {
+	ledger.mtx.Lock()
+	defer ledger.mtx.Unlock()
+
+	if ledger.closed() {
+		return xerrors.NewOrdinary("mutable ledger is closed")
+	}
+	return ledger.cache.Write()
+}
+
+func (ledger *MutableLedger) NewItem(key LedgerKey) ILedgerItem {
+	if ledger.newItemFor == nil {
+		return nil
+	}
+	return ledger.newItemFor(key)
+}
+
+func (ledger *MutableLedger) Get(key LedgerKey) (ILedgerItem, xerrors.XError) {
+	ledger.mtx.RLock()
+	defer ledger.mtx.RUnlock()
+
+	if ledger.closed() {
+		return nil, xerrors.NewOrdinary("mutable ledger is closed")
+	}
+	bz, ok, xerr := ledger.cache.Get(key)
+	if xerr != nil {
+		return nil, xerr
+	}
+	if !ok {
+		return nil, xerrors.ErrNotFoundResult
+	}
+
+	item := ledger.newItemFor(key)
+	if item == nil {
+		return nil, xerrors.NewOrdinary("mutable ledger item factory returned nil")
+	}
+	if xerr := item.Decode(key, bz); xerr != nil {
+		return nil, xerr
+	}
+	return item, nil
+}
+
+func (ledger *MutableLedger) Set(key LedgerKey, item ILedgerItem) xerrors.XError {
+	ledger.mtx.Lock()
+	defer ledger.mtx.Unlock()
+
+	if ledger.closed() {
+		return xerrors.NewOrdinary("mutable ledger is closed")
+	}
+	if item == nil {
+		return xerrors.NewOrdinary("mutable ledger item is nil")
+	}
+	// bz is the encoded form written to the cache layer.
+	bz, xerr := item.Encode()
+	if xerr != nil {
+		return xerr
+	}
+	return ledger.cache.Set(key, bz)
+}
+
+func (ledger *MutableLedger) Del(key LedgerKey) xerrors.XError {
+	ledger.mtx.Lock()
+	defer ledger.mtx.Unlock()
+
+	if ledger.closed() {
+		return xerrors.NewOrdinary("mutable ledger is closed")
+	}
+	return ledger.cache.Delete(key)
+}
+
+func (ledger *MutableLedger) Iterate(cb FuncIterate) xerrors.XError {
+	return ledger.Seek(nil, true, cb)
+}
+
+func (ledger *MutableLedger) Seek(prefix []byte, ascending bool, cb FuncIterate) xerrors.XError {
+	ledger.mtx.RLock()
+	defer ledger.mtx.RUnlock()
+
+	if ledger.closed() {
+		return xerrors.NewOrdinary("mutable ledger is closed")
+	}
+	if cb == nil {
+		return xerrors.NewOrdinary("mutable ledger iterator callback is nil")
+	}
+	keys, xerr := ledger.seekKeys(prefix, ascending)
+	if xerr != nil {
+		return xerr
+	}
+
+	for _, key := range keys {
+		bz, ok, xerr := ledger.cache.Get(key)
+		if xerr != nil {
+			return xerr
+		}
+		if !ok {
+			continue
+		}
+
+		item := ledger.newItemFor(key)
+		if item == nil {
+			return xerrors.NewOrdinary("mutable ledger item factory returned nil")
+		}
+		if xerr := item.Decode(key, bz); xerr != nil {
+			return xerr
+		}
+		if xerr := cb(key, item); xerr != nil {
+			return xerr
+		}
+	}
+	return nil
+}
+
+func (ledger *MutableLedger) seekKeys(prefix []byte, ascending bool) ([][]byte, xerrors.XError) {
+	keys := make(map[string][]byte)
+	iter, err := ledger.tree.Iterator(prefix, nil, true)
+	if err != nil {
+		return nil, xerrors.From(err)
+	}
+	defer func() {
+		_ = iter.Close()
+	}()
+
+	for ; iter.Valid(); iter.Next() {
+		key := iter.Key()
+		if !bytes.HasPrefix(key, prefix) {
+			break
+		}
+		keys[string(key)] = cloneBytes(key)
+	}
+
+	for _, key := range ledger.cache.keysWithPrefixDeep(prefix) {
+		keys[string(key)] = cloneBytes(key)
+	}
+
+	ret := make([][]byte, 0, len(keys))
+	for _, key := range keys {
+		ret = append(ret, key)
+	}
+	sortLedgerKeys(ret, ascending)
+	return ret, nil
+}
+
+func (ledger *MutableLedger) Commit() ([]byte, int64, xerrors.XError) {
+	ledger.mtx.Lock()
+	defer ledger.mtx.Unlock()
+
+	if ledger.closed() {
+		return nil, 0, xerrors.NewOrdinary("mutable ledger is closed")
+	}
+	if xerr := ledger.cache.Write(); xerr != nil {
+		return nil, 0, xerr
+	}
+
+	ledger.tree.SetCommitting()
+	defer ledger.tree.UnsetCommitting()
+
+	hash, ver, err := ledger.tree.SaveVersion()
+	if err != nil {
+		return hash, ver, xerrors.From(err)
+	}
+
+	ledger.cache = newCacheContext(&mutableTreeStore{tree: ledger.tree})
+	ledger.logger.Debug("tree save version", "hash", hash, "version", ver)
+	return hash, ver, nil
+}
+
+func (ledger *MutableLedger) Version() int64 {
+	ledger.mtx.RLock()
+	defer ledger.mtx.RUnlock()
+
+	if ledger.closed() {
+		return 0
+	}
+	return ledger.tree.Version()
+}
+
+func (ledger *MutableLedger) GetReadOnlyTree(ver int64) (*iavl.ImmutableTree, xerrors.XError) {
+	ledger.mtx.RLock()
+	defer ledger.mtx.RUnlock()
+
+	if ledger.closed() {
+		return nil, xerrors.NewOrdinary("mutable ledger is closed")
+	}
+	tree, err := ledger.tree.GetImmutable(ver)
+	if err != nil {
+		return nil, xerrors.From(err)
+	}
+	return tree, nil
+}
+
+func (ledger *MutableLedger) Close() xerrors.XError {
+	ledger.mtx.Lock()
+	defer ledger.mtx.Unlock()
+
+	if ledger.tree != nil {
+		if err := ledger.tree.Close(); err != nil {
+			return xerrors.From(err)
+		}
+	}
+	ledger.tree = nil
+
+	if ledger.db != nil {
+		if err := ledger.db.Close(); err != nil {
+			return xerrors.From(err)
+		}
+	}
+	ledger.db = nil
+	ledger.cache = nil
+	return nil
+}

--- a/ledger/v2/mutable_ledger_test.go
+++ b/ledger/v2/mutable_ledger_test.go
@@ -1,0 +1,315 @@
+package v2
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/beatoz/beatoz-go/types/xerrors"
+	"github.com/stretchr/testify/require"
+	"github.com/tendermint/tendermint/libs/log"
+)
+
+func TestMutableLedgerCacheWrite(t *testing.T) {
+	ledger := newMutableLedgerForTest(t)
+	require.NoError(t, ledger.Set(testLedgerKey(1), newTestLedgerItem(1, "parent")))
+
+	child := ledger.CacheWrap()
+	require.NoError(t, child.Set(testLedgerKey(2), newTestLedgerItem(2, "child")))
+
+	_, xerr := ledger.Get(testLedgerKey(2))
+	require.Error(t, xerr)
+	require.True(t, xerr.Contains(xerrors.ErrNotFoundResult))
+
+	require.NoError(t, child.Write())
+	item, xerr := ledger.Get(testLedgerKey(2))
+	require.NoError(t, xerr)
+	require.Equal(t, "child", item.(*testLedgerItem).data)
+}
+
+func TestMutableLedgerCacheDiscard(t *testing.T) {
+	ledger := newMutableLedgerForTest(t)
+
+	child := ledger.CacheWrap()
+	require.NoError(t, child.Set(testLedgerKey(1), newTestLedgerItem(1, "child")))
+	child = nil
+
+	_, xerr := ledger.Get(testLedgerKey(1))
+	require.Error(t, xerr)
+	require.True(t, xerr.Contains(xerrors.ErrNotFoundResult))
+	require.Nil(t, child)
+}
+
+func TestMutableLedgerCachePrecedence(t *testing.T) {
+	ledger := newMutableLedgerForTest(t)
+	require.NoError(t, ledger.Set(testLedgerKey(1), newTestLedgerItem(1, "tree")))
+	_, _, xerr := ledger.Commit()
+	require.NoError(t, xerr)
+
+	require.NoError(t, ledger.Set(testLedgerKey(1), newTestLedgerItem(1, "parent")))
+	child := ledger.CacheWrap()
+	require.NoError(t, child.Set(testLedgerKey(1), newTestLedgerItem(1, "child")))
+
+	item, xerr := child.Get(testLedgerKey(1))
+	require.NoError(t, xerr)
+	require.Equal(t, "child", item.(*testLedgerItem).data)
+
+	item, xerr = ledger.Get(testLedgerKey(1))
+	require.NoError(t, xerr)
+	require.Equal(t, "parent", item.(*testLedgerItem).data)
+
+	require.NoError(t, child.Write())
+	item, xerr = ledger.Get(testLedgerKey(1))
+	require.NoError(t, xerr)
+	require.Equal(t, "child", item.(*testLedgerItem).data)
+}
+
+func TestMutableLedgerLastWriteWins(t *testing.T) {
+	ledger := newMutableLedgerForTest(t)
+
+	require.NoError(t, ledger.Set(testLedgerKey(1), newTestLedgerItem(1, "first")))
+	require.NoError(t, ledger.Del(testLedgerKey(1)))
+	require.NoError(t, ledger.Set(testLedgerKey(1), newTestLedgerItem(1, "final")))
+
+	item, xerr := ledger.Get(testLedgerKey(1))
+	require.NoError(t, xerr)
+	require.Equal(t, "final", item.(*testLedgerItem).data)
+
+	_, _, xerr = ledger.Commit()
+	require.NoError(t, xerr)
+
+	item, xerr = ledger.Get(testLedgerKey(1))
+	require.NoError(t, xerr)
+	require.Equal(t, "final", item.(*testLedgerItem).data)
+}
+
+func TestMutableLedgerUnwrittenChild(t *testing.T) {
+	ledger := newMutableLedgerForTest(t)
+
+	child := ledger.CacheWrap()
+	require.NoError(t, child.Set(testLedgerKey(1), newTestLedgerItem(1, "child")))
+
+	_, ver, xerr := ledger.Commit()
+	require.NoError(t, xerr)
+	require.EqualValues(t, 1, ver)
+
+	_, xerr = ledger.Get(testLedgerKey(1))
+	require.Error(t, xerr)
+	require.True(t, xerr.Contains(xerrors.ErrNotFoundResult))
+
+	readonly, xerr := ledger.GetReadOnlyTree(ver)
+	require.NoError(t, xerr)
+	raw, err := readonly.Get(testLedgerKey(1))
+	require.NoError(t, err)
+	require.Nil(t, raw)
+}
+
+func TestMutableLedgerSetDel(t *testing.T) {
+	ledger := newMutableLedgerForTest(t)
+
+	require.NoError(t, ledger.Set(testLedgerKey(1), newTestLedgerItem(1, "one")))
+	require.NoError(t, ledger.Del(testLedgerKey(1)))
+
+	_, xerr := ledger.Get(testLedgerKey(1))
+	require.Error(t, xerr)
+	require.True(t, xerr.Contains(xerrors.ErrNotFoundResult))
+
+	_, ver, xerr := ledger.Commit()
+	require.NoError(t, xerr)
+
+	readonly, xerr := ledger.GetReadOnlyTree(ver)
+	require.NoError(t, xerr)
+	raw, err := readonly.Get(testLedgerKey(1))
+	require.NoError(t, err)
+	require.Nil(t, raw)
+}
+
+func TestMutableLedgerParentKept(t *testing.T) {
+	ledger := newMutableLedgerForTest(t)
+	require.NoError(t, ledger.Set(testLedgerKey(1), newTestLedgerItem(1, "parent")))
+
+	child := ledger.CacheWrap()
+	require.NoError(t, child.Set(testLedgerKey(1), newTestLedgerItem(1, "child")))
+	require.NoError(t, child.Set(testLedgerKey(2), newTestLedgerItem(2, "child")))
+	child = nil
+
+	item, xerr := ledger.Get(testLedgerKey(1))
+	require.NoError(t, xerr)
+	require.Equal(t, "parent", item.(*testLedgerItem).data)
+
+	_, xerr = ledger.Get(testLedgerKey(2))
+	require.Error(t, xerr)
+	require.True(t, xerr.Contains(xerrors.ErrNotFoundResult))
+	require.Nil(t, child)
+}
+
+func TestMutableLedgerGetCopy(t *testing.T) {
+	ledger := newMutableLedgerForTest(t)
+	require.NoError(t, ledger.Set(testLedgerKey(1), newTestLedgerItem(1, "one")))
+
+	item, xerr := ledger.Get(testLedgerKey(1))
+	require.NoError(t, xerr)
+	item.(*testLedgerItem).data = "mutated"
+
+	item, xerr = ledger.Get(testLedgerKey(1))
+	require.NoError(t, xerr)
+	require.Equal(t, "one", item.(*testLedgerItem).data)
+}
+
+func TestMutableLedgerCommitFlushesCache(t *testing.T) {
+	ledger := newMutableLedgerForTest(t)
+
+	require.NoError(t, ledger.Set(testLedgerKey(1), newTestLedgerItem(1, "one")))
+
+	raw, err := ledger.tree.Get(testLedgerKey(1))
+	require.NoError(t, err)
+	require.Nil(t, raw)
+
+	_, ver, xerr := ledger.Commit()
+	require.NoError(t, xerr)
+	require.EqualValues(t, 1, ver)
+
+	raw, err = ledger.tree.Get(testLedgerKey(1))
+	require.NoError(t, err)
+	require.NotNil(t, raw)
+
+	readonly, xerr := ledger.GetReadOnlyTree(ver)
+	require.NoError(t, xerr)
+	raw, err = readonly.Get(testLedgerKey(1))
+	require.NoError(t, err)
+	require.NotNil(t, raw)
+}
+
+func TestMutableLedgerDeleteShadow(t *testing.T) {
+	ledger := newMutableLedgerForTest(t)
+	require.NoError(t, ledger.Set(testLedgerKey(1), newTestLedgerItem(1, "one")))
+	_, _, xerr := ledger.Commit()
+	require.NoError(t, xerr)
+
+	child := ledger.CacheWrap()
+	require.NoError(t, child.Del(testLedgerKey(1)))
+
+	item, xerr := ledger.Get(testLedgerKey(1))
+	require.NoError(t, xerr)
+	require.Equal(t, "one", item.(*testLedgerItem).data)
+
+	_, xerr = child.Get(testLedgerKey(1))
+	require.Error(t, xerr)
+	require.True(t, xerr.Contains(xerrors.ErrNotFoundResult))
+
+	require.NoError(t, child.Write())
+	_, xerr = ledger.Get(testLedgerKey(1))
+	require.Error(t, xerr)
+	require.True(t, xerr.Contains(xerrors.ErrNotFoundResult))
+}
+
+func TestMutableLedgerSeekOverlay(t *testing.T) {
+	ledger := newMutableLedgerForTest(t)
+	require.NoError(t, ledger.Set(testLedgerKey(1), newTestLedgerItem(1, "one")))
+	require.NoError(t, ledger.Set(testLedgerKey(3), newTestLedgerItem(3, "three")))
+	_, _, xerr := ledger.Commit()
+	require.NoError(t, xerr)
+
+	require.NoError(t, ledger.Set(testLedgerKey(2), newTestLedgerItem(2, "two")))
+	require.NoError(t, ledger.Del(testLedgerKey(3)))
+
+	var got []string
+	xerr = ledger.Seek(nil, true, func(_ LedgerKey, item ILedgerItem) xerrors.XError {
+		got = append(got, item.(*testLedgerItem).data)
+		return nil
+	})
+	require.NoError(t, xerr)
+	require.Equal(t, []string{"one", "two"}, got)
+}
+
+func TestMutableLedgerSeekUpdated(t *testing.T) {
+	ledger := newMutableLedgerForTest(t)
+	require.NoError(t, ledger.Set(testLedgerKey(1), newTestLedgerItem(1, "one")))
+	require.NoError(t, ledger.Set(testLedgerKey(2), newTestLedgerItem(2, "two")))
+	_, _, xerr := ledger.Commit()
+	require.NoError(t, xerr)
+
+	require.NoError(t, ledger.Set(testLedgerKey(1), newTestLedgerItem(1, "uno")))
+
+	var got []string
+	xerr = ledger.Seek(nil, true, func(_ LedgerKey, item ILedgerItem) xerrors.XError {
+		got = append(got, item.(*testLedgerItem).data)
+		return nil
+	})
+	require.NoError(t, xerr)
+	require.Equal(t, []string{"uno", "two"}, got)
+}
+
+func TestMutableLedgerSeekDesc(t *testing.T) {
+	ledger := newMutableLedgerForTest(t)
+	require.NoError(t, ledger.Set(testLedgerKey(1), newTestLedgerItem(1, "one")))
+	require.NoError(t, ledger.Set(testLedgerKey(3), newTestLedgerItem(3, "three")))
+	_, _, xerr := ledger.Commit()
+	require.NoError(t, xerr)
+	require.NoError(t, ledger.Set(testLedgerKey(2), newTestLedgerItem(2, "two")))
+
+	var got []int
+	xerr = ledger.Seek(nil, false, func(key LedgerKey, _ ILedgerItem) xerrors.XError {
+		got = append(got, int(binary.BigEndian.Uint32(key)))
+		return nil
+	})
+	require.NoError(t, xerr)
+	require.Equal(t, []int{3, 2, 1}, got)
+}
+
+func TestMutableLedgerMissingVersion(t *testing.T) {
+	ledger := newMutableLedgerForTest(t)
+
+	_, xerr := ledger.GetReadOnlyTree(1)
+	require.Error(t, xerr)
+}
+
+func TestMutableLedgerGuards(t *testing.T) {
+	ledger := newMutableLedgerForTest(t)
+
+	require.NotPanics(t, func() {
+		require.Error(t, ledger.Set(testLedgerKey(1), nil))
+	})
+	require.NotPanics(t, func() {
+		require.Error(t, ledger.Seek(nil, true, nil))
+	})
+
+	require.NoError(t, ledger.Set(testLedgerKey(1), newTestLedgerItem(1, "one")))
+	ledger.newItemFor = func(LedgerKey) ILedgerItem {
+		return nil
+	}
+	require.NotPanics(t, func() {
+		_, xerr := ledger.Get(testLedgerKey(1))
+		require.Error(t, xerr)
+	})
+
+	require.NoError(t, ledger.Close())
+	require.EqualValues(t, 0, ledger.Version())
+	require.Nil(t, ledger.CacheWrap())
+	require.NotPanics(t, func() {
+		_, xerr := ledger.Get(testLedgerKey(1))
+		require.Error(t, xerr)
+	})
+	require.Error(t, ledger.Write())
+	require.Error(t, ledger.Set(testLedgerKey(1), newTestLedgerItem(1, "one")))
+	require.Error(t, ledger.Del(testLedgerKey(1)))
+	require.Error(t, ledger.Seek(nil, true, func(LedgerKey, ILedgerItem) xerrors.XError {
+		return nil
+	}))
+	_, _, xerr := ledger.Commit()
+	require.Error(t, xerr)
+	_, xerr = ledger.GetReadOnlyTree(1)
+	require.Error(t, xerr)
+}
+
+func newMutableLedgerForTest(t *testing.T) *MutableLedger {
+	t.Helper()
+
+	ledger, xerr := NewMutableLedger("mutable_ledger_test", t.TempDir(), 100, func(LedgerKey) ILedgerItem {
+		return &testLedgerItem{}
+	}, log.NewNopLogger())
+	require.NoError(t, xerr)
+	t.Cleanup(func() {
+		require.NoError(t, ledger.Close())
+	})
+	return ledger
+}

--- a/ledger/v2/state_ledger.go
+++ b/ledger/v2/state_ledger.go
@@ -1,0 +1,184 @@
+package v2
+
+import (
+	"sync"
+
+	"github.com/beatoz/beatoz-go/types/xerrors"
+	tmlog "github.com/tendermint/tendermint/libs/log"
+)
+
+type StateLedger struct {
+	commitLedger   *MutableLedger
+	imitableLedger *MemLedger
+
+	logger tmlog.Logger
+	mtx    sync.RWMutex
+}
+
+var _ IStateLedger = (*StateLedger)(nil)
+
+func NewStateLedger(name, dbDir string, cacheSize int, newItem FuncNewItemFor, lg tmlog.Logger) (*StateLedger, xerrors.XError) {
+	commitLedger, xerr := NewMutableLedger(name, dbDir, cacheSize, newItem, lg)
+	if xerr != nil {
+		return nil, xerr
+	}
+
+	imitableLedger, xerr := NewMemLedgerAt(commitLedger.Version(), commitLedger, lg)
+	if xerr != nil {
+		_ = commitLedger.Close()
+		return nil, xerr
+	}
+
+	return newStateLedger(commitLedger, imitableLedger, lg), nil
+}
+
+func newStateLedger(commitLedger *MutableLedger, imitableLedger *MemLedger, lg tmlog.Logger) *StateLedger {
+	return &StateLedger{
+		commitLedger:   commitLedger,
+		imitableLedger: imitableLedger,
+		logger:         lg.With("ledger", "StateLedger"),
+	}
+}
+
+func (ledger *StateLedger) getLedger(exec bool) IImitable {
+	if exec {
+		return ledger.commitLedger
+	}
+	return ledger.imitableLedger
+}
+
+func (ledger *StateLedger) closed() bool {
+	return ledger.commitLedger == nil || ledger.imitableLedger == nil
+}
+
+func (ledger *StateLedger) Version() int64 {
+	ledger.mtx.RLock()
+	defer ledger.mtx.RUnlock()
+
+	if ledger.closed() {
+		return 0
+	}
+	return ledger.commitLedger.Version()
+}
+
+func (ledger *StateLedger) Get(key LedgerKey, exec bool) (ILedgerItem, xerrors.XError) {
+	ledger.mtx.RLock()
+	defer ledger.mtx.RUnlock()
+
+	if ledger.closed() {
+		return nil, xerrors.NewOrdinary("state ledger is closed")
+	}
+	return ledger.getLedger(exec).Get(key)
+}
+
+func (ledger *StateLedger) Iterate(cb FuncIterate, exec bool) xerrors.XError {
+	ledger.mtx.RLock()
+	defer ledger.mtx.RUnlock()
+
+	if ledger.closed() {
+		return xerrors.NewOrdinary("state ledger is closed")
+	}
+	return ledger.getLedger(exec).Iterate(cb)
+}
+
+func (ledger *StateLedger) Seek(prefix []byte, ascending bool, cb FuncIterate, exec bool) xerrors.XError {
+	ledger.mtx.RLock()
+	defer ledger.mtx.RUnlock()
+
+	if ledger.closed() {
+		return xerrors.NewOrdinary("state ledger is closed")
+	}
+	return ledger.getLedger(exec).Seek(prefix, ascending, cb)
+}
+
+func (ledger *StateLedger) Set(key LedgerKey, item ILedgerItem, exec bool) xerrors.XError {
+	ledger.mtx.Lock()
+	defer ledger.mtx.Unlock()
+
+	if ledger.closed() {
+		return xerrors.NewOrdinary("state ledger is closed")
+	}
+	return ledger.getLedger(exec).Set(key, item)
+}
+
+func (ledger *StateLedger) Del(key LedgerKey, exec bool) xerrors.XError {
+	ledger.mtx.Lock()
+	defer ledger.mtx.Unlock()
+
+	if ledger.closed() {
+		return xerrors.NewOrdinary("state ledger is closed")
+	}
+	return ledger.getLedger(exec).Del(key)
+}
+
+func (ledger *StateLedger) CacheContext(exec bool) (IStateLedger, func() xerrors.XError) {
+	ledger.mtx.RLock()
+	defer ledger.mtx.RUnlock()
+
+	if ledger.closed() {
+		return nil, func() xerrors.XError {
+			return xerrors.NewOrdinary("state ledger is closed")
+		}
+	}
+	if exec {
+		cachedCommitLedger := ledger.commitLedger.CacheWrap()
+		if cachedCommitLedger == nil {
+			return nil, func() xerrors.XError {
+				return xerrors.NewOrdinary("state ledger commit cache is unavailable")
+			}
+		}
+		return newStateLedger(cachedCommitLedger, ledger.imitableLedger, ledger.logger), cachedCommitLedger.Write
+	}
+
+	cachedImitableLedger := ledger.imitableLedger.CacheWrap()
+	if cachedImitableLedger == nil {
+		return nil, func() xerrors.XError {
+			return xerrors.NewOrdinary("state ledger imitable cache is unavailable")
+		}
+	}
+	return newStateLedger(ledger.commitLedger, cachedImitableLedger, ledger.logger), cachedImitableLedger.Write
+}
+
+func (ledger *StateLedger) Commit() ([]byte, int64, xerrors.XError) {
+	ledger.mtx.Lock()
+	defer ledger.mtx.Unlock()
+
+	if ledger.closed() {
+		return nil, 0, xerrors.NewOrdinary("state ledger is closed")
+	}
+	hash, ver, xerr := ledger.commitLedger.Commit()
+	if xerr != nil {
+		return nil, 0, xerr
+	}
+
+	ledger.imitableLedger, xerr = NewMemLedgerAt(ver, ledger.commitLedger, ledger.logger)
+	if xerr != nil {
+		return nil, 0, xerr
+	}
+
+	return hash, ver, nil
+}
+
+func (ledger *StateLedger) Close() xerrors.XError {
+	ledger.mtx.Lock()
+	defer ledger.mtx.Unlock()
+
+	if ledger.commitLedger != nil {
+		if xerr := ledger.commitLedger.Close(); xerr != nil {
+			return xerr
+		}
+		ledger.commitLedger = nil
+	}
+	ledger.imitableLedger = nil
+	return nil
+}
+
+func (ledger *StateLedger) ImitableLedgerAt(height int64) (IImitable, xerrors.XError) {
+	ledger.mtx.RLock()
+	defer ledger.mtx.RUnlock()
+
+	if ledger.closed() {
+		return nil, xerrors.NewOrdinary("state ledger is closed")
+	}
+	return NewMemLedgerAt(height, ledger.commitLedger, ledger.logger)
+}

--- a/ledger/v2/state_ledger_test.go
+++ b/ledger/v2/state_ledger_test.go
@@ -1,0 +1,128 @@
+package v2
+
+import (
+	"testing"
+
+	"github.com/beatoz/beatoz-go/types/xerrors"
+	"github.com/stretchr/testify/require"
+	"github.com/tendermint/tendermint/libs/log"
+)
+
+func TestStateLedgerExecCacheWrite(t *testing.T) {
+	ledger := newStateLedgerForTest(t)
+
+	cached, writeCache := ledger.CacheContext(true)
+	require.NoError(t, cached.Set(testLedgerKey(1), newTestLedgerItem(1, "tx"), true))
+
+	_, xerr := ledger.Get(testLedgerKey(1), true)
+	require.Error(t, xerr)
+	require.True(t, xerr.Contains(xerrors.ErrNotFoundResult))
+
+	require.NoError(t, writeCache())
+
+	item, xerr := ledger.Get(testLedgerKey(1), true)
+	require.NoError(t, xerr)
+	require.Equal(t, "tx", item.(*testLedgerItem).data)
+}
+
+func TestStateLedgerExecCacheDiscard(t *testing.T) {
+	ledger := newStateLedgerForTest(t)
+
+	cached, _ := ledger.CacheContext(true)
+	require.NoError(t, cached.Set(testLedgerKey(1), newTestLedgerItem(1, "tx"), true))
+	cached = nil
+
+	_, xerr := ledger.Get(testLedgerKey(1), true)
+	require.Error(t, xerr)
+	require.True(t, xerr.Contains(xerrors.ErrNotFoundResult))
+	require.Nil(t, cached)
+}
+
+func TestStateLedgerCommitRefreshesImitable(t *testing.T) {
+	ledger := newStateLedgerForTest(t)
+
+	require.NoError(t, ledger.Set(testLedgerKey(1), newTestLedgerItem(1, "one"), true))
+	_, ver, xerr := ledger.Commit()
+	require.NoError(t, xerr)
+	require.EqualValues(t, 1, ver)
+
+	item, xerr := ledger.Get(testLedgerKey(1), false)
+	require.NoError(t, xerr)
+	require.Equal(t, "one", item.(*testLedgerItem).data)
+
+	atLedger, xerr := ledger.ImitableLedgerAt(ver)
+	require.NoError(t, xerr)
+	item, xerr = atLedger.Get(testLedgerKey(1))
+	require.NoError(t, xerr)
+	require.Equal(t, "one", item.(*testLedgerItem).data)
+}
+
+func TestStateLedgerMemCacheWrite(t *testing.T) {
+	ledger := newStateLedgerForTest(t)
+	require.NoError(t, ledger.Set(testLedgerKey(1), newTestLedgerItem(1, "one"), true))
+	_, _, xerr := ledger.Commit()
+	require.NoError(t, xerr)
+
+	cached, writeCache := ledger.CacheContext(false)
+	require.NoError(t, cached.Set(testLedgerKey(2), newTestLedgerItem(2, "check"), false))
+
+	_, xerr = ledger.Get(testLedgerKey(2), false)
+	require.Error(t, xerr)
+	require.True(t, xerr.Contains(xerrors.ErrNotFoundResult))
+
+	require.NoError(t, writeCache())
+
+	item, xerr := ledger.Get(testLedgerKey(2), false)
+	require.NoError(t, xerr)
+	require.Equal(t, "check", item.(*testLedgerItem).data)
+
+	_, xerr = ledger.Get(testLedgerKey(2), true)
+	require.Error(t, xerr)
+	require.True(t, xerr.Contains(xerrors.ErrNotFoundResult))
+}
+
+func TestStateLedgerGuards(t *testing.T) {
+	ledger := newStateLedgerForTest(t)
+
+	require.NotPanics(t, func() {
+		require.Error(t, ledger.Set(testLedgerKey(1), nil, true))
+	})
+	require.NotPanics(t, func() {
+		require.Error(t, ledger.Seek(nil, true, nil, true))
+	})
+
+	require.NoError(t, ledger.Close())
+	require.EqualValues(t, 0, ledger.Version())
+	require.NotPanics(t, func() {
+		_, xerr := ledger.Get(testLedgerKey(1), true)
+		require.Error(t, xerr)
+	})
+	require.Error(t, ledger.Iterate(func(LedgerKey, ILedgerItem) xerrors.XError {
+		return nil
+	}, true))
+	require.Error(t, ledger.Seek(nil, true, func(LedgerKey, ILedgerItem) xerrors.XError {
+		return nil
+	}, true))
+	require.Error(t, ledger.Set(testLedgerKey(1), newTestLedgerItem(1, "one"), true))
+	require.Error(t, ledger.Del(testLedgerKey(1), true))
+	cached, writeCache := ledger.CacheContext(true)
+	require.Nil(t, cached)
+	require.Error(t, writeCache())
+	_, _, xerr := ledger.Commit()
+	require.Error(t, xerr)
+	_, xerr = ledger.ImitableLedgerAt(1)
+	require.Error(t, xerr)
+}
+
+func newStateLedgerForTest(t *testing.T) *StateLedger {
+	t.Helper()
+
+	ledger, xerr := NewStateLedger("state_ledger_test", t.TempDir(), 100, func(LedgerKey) ILedgerItem {
+		return &testLedgerItem{}
+	}, log.NewNopLogger())
+	require.NoError(t, xerr)
+	t.Cleanup(func() {
+		require.NoError(t, ledger.Close())
+	})
+	return ledger
+}

--- a/ledger/v2/types.go
+++ b/ledger/v2/types.go
@@ -1,0 +1,96 @@
+package v2
+
+import (
+	"bytes"
+	"sort"
+
+	"github.com/beatoz/beatoz-go/types/xerrors"
+	"github.com/cosmos/iavl"
+)
+
+type FuncNewItemFor func(LedgerKey) ILedgerItem
+type FuncIterate func(LedgerKey, ILedgerItem) xerrors.XError
+
+type IGettable interface {
+	Get(LedgerKey) (ILedgerItem, xerrors.XError)
+	Iterate(FuncIterate) xerrors.XError
+	Seek([]byte, bool, FuncIterate) xerrors.XError
+}
+
+type ISettable interface {
+	Set(LedgerKey, ILedgerItem) xerrors.XError
+	Del(LedgerKey) xerrors.XError
+}
+
+type ICommittable interface {
+	Commit() ([]byte, int64, xerrors.XError)
+}
+
+type IImitable interface {
+	IGettable
+	ISettable
+}
+
+type IMutable interface {
+	IGettable
+	ISettable
+	ICommittable
+	Version() int64
+	GetReadOnlyTree(int64) (*iavl.ImmutableTree, xerrors.XError)
+	NewItem(LedgerKey) ILedgerItem
+	Close() xerrors.XError
+}
+
+type IStateLedger interface {
+	Version() int64
+	Get(LedgerKey, bool) (ILedgerItem, xerrors.XError)
+	Iterate(FuncIterate, bool) xerrors.XError
+	Seek([]byte, bool, FuncIterate, bool) xerrors.XError
+	Set(LedgerKey, ILedgerItem, bool) xerrors.XError
+	Del(LedgerKey, bool) xerrors.XError
+	CacheContext(bool) (IStateLedger, func() xerrors.XError)
+	Commit() ([]byte, int64, xerrors.XError)
+	Close() xerrors.XError
+	ImitableLedgerAt(int64) (IImitable, xerrors.XError)
+}
+
+type ILedgerItem interface {
+	Encode() ([]byte, xerrors.XError)
+	Decode([]byte, []byte) xerrors.XError
+}
+
+type invalidLedgerItem struct {
+	err xerrors.XError
+}
+
+func NewInvalidLedgerItem(format string, args ...any) ILedgerItem {
+	return &invalidLedgerItem{
+		err: xerrors.ErrInvalidLedgerKey.Wrapf(format, args...),
+	}
+}
+
+func (item *invalidLedgerItem) Encode() ([]byte, xerrors.XError) {
+	return nil, item.err
+}
+
+func (item *invalidLedgerItem) Decode(_, _ []byte) xerrors.XError {
+	return item.err
+}
+
+type LedgerKey = []byte
+
+type LedgerKeyList []LedgerKey
+
+func (a LedgerKeyList) Len() int {
+	return len(a)
+}
+func (a LedgerKeyList) Less(i, j int) bool {
+	ret := bytes.Compare(a[i][:], a[j][:])
+	return ret > 0
+}
+func (a LedgerKeyList) Swap(i, j int) {
+	a[i], a[j] = a[j], a[i]
+}
+
+var _ sort.Interface = LedgerKeyList(nil)
+var _ ILedgerItem = (*invalidLedgerItem)(nil)

--- a/ledger/v2/write_set.go
+++ b/ledger/v2/write_set.go
@@ -1,0 +1,112 @@
+package v2
+
+import (
+	"bytes"
+	"sort"
+)
+
+type writeOp uint8
+
+const (
+	opSet writeOp = iota + 1
+	opDel
+)
+
+type writeEntry struct {
+	key []byte
+	val []byte
+	op  writeOp
+}
+
+type writeSet struct {
+	entries map[string]*writeEntry
+}
+
+func newWriteSet() *writeSet {
+	return &writeSet{
+		entries: make(map[string]*writeEntry),
+	}
+}
+
+func (ws *writeSet) set(key, val []byte) {
+	if ws == nil {
+		return
+	}
+	ws.entries[string(key)] = &writeEntry{
+		key: cloneBytes(key),
+		val: cloneBytes(val),
+		op:  opSet,
+	}
+}
+
+func (ws *writeSet) del(key []byte) {
+	if ws == nil {
+		return
+	}
+	ws.entries[string(key)] = &writeEntry{
+		key: cloneBytes(key),
+		op:  opDel,
+	}
+}
+
+func (ws *writeSet) get(key []byte) (*writeEntry, bool) {
+	if ws == nil {
+		return nil, false
+	}
+	entry, ok := ws.entries[string(key)]
+	return entry, ok
+}
+
+func (ws *writeSet) reset() {
+	if ws == nil {
+		return
+	}
+	ws.entries = make(map[string]*writeEntry)
+}
+
+func (ws *writeSet) orderedEntries(ascending bool) []*writeEntry {
+	if ws == nil || len(ws.entries) == 0 {
+		return nil
+	}
+
+	ret := make([]*writeEntry, 0, len(ws.entries))
+	for _, entry := range ws.entries {
+		ret = append(ret, entry)
+	}
+
+	sort.Slice(ret, func(i, j int) bool {
+		cmp := bytes.Compare(ret[i].key, ret[j].key)
+		if ascending {
+			return cmp < 0
+		}
+		return cmp > 0
+	})
+	return ret
+}
+
+func (ws *writeSet) keysWithPrefix(prefix []byte) [][]byte {
+	if ws == nil || len(ws.entries) == 0 {
+		return nil
+	}
+
+	keys := make([][]byte, 0, len(ws.entries))
+	for _, entry := range ws.entries {
+		if bytes.HasPrefix(entry.key, prefix) {
+			keys = append(keys, cloneBytes(entry.key))
+		}
+	}
+
+	sort.Slice(keys, func(i, j int) bool {
+		return bytes.Compare(keys[i], keys[j]) < 0
+	})
+	return keys
+}
+
+func cloneBytes(src []byte) []byte {
+	if src == nil {
+		return nil
+	}
+	dst := make([]byte, len(src))
+	copy(dst, src)
+	return dst
+}

--- a/ledger/v2/write_set_test.go
+++ b/ledger/v2/write_set_test.go
@@ -1,0 +1,73 @@
+package v2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteSetSetCopiesInput(t *testing.T) {
+	ws := newWriteSet()
+
+	key := []byte{0x01}
+	val := []byte("value")
+	ws.set(key, val)
+
+	key[0] = 0xff
+	val[0] = 'X'
+
+	entry, ok := ws.get([]byte{0x01})
+	require.True(t, ok)
+	require.Equal(t, []byte{0x01}, entry.key)
+	require.Equal(t, []byte("value"), entry.val)
+	require.Equal(t, opSet, entry.op)
+}
+
+func TestWriteSetLastWriteWins(t *testing.T) {
+	ws := newWriteSet()
+	key := []byte{0x01}
+
+	ws.set(key, []byte("first"))
+	ws.del(key)
+
+	entry, ok := ws.get(key)
+	require.True(t, ok)
+	require.Equal(t, opDel, entry.op)
+	require.Nil(t, entry.val)
+
+	ws.set(key, []byte("second"))
+	entry, ok = ws.get(key)
+	require.True(t, ok)
+	require.Equal(t, opSet, entry.op)
+	require.Equal(t, []byte("second"), entry.val)
+}
+
+func TestWriteSetOrderedEntries(t *testing.T) {
+	ws := newWriteSet()
+	ws.set([]byte{0x02}, []byte("2"))
+	ws.set([]byte{0x01}, []byte("1"))
+	ws.del([]byte{0x03})
+
+	ascending := ws.orderedEntries(true)
+	require.Equal(t, []byte{0x01}, ascending[0].key)
+	require.Equal(t, []byte{0x02}, ascending[1].key)
+	require.Equal(t, []byte{0x03}, ascending[2].key)
+
+	descending := ws.orderedEntries(false)
+	require.Equal(t, []byte{0x03}, descending[0].key)
+	require.Equal(t, []byte{0x02}, descending[1].key)
+	require.Equal(t, []byte{0x01}, descending[2].key)
+}
+
+func TestWriteSetKeysWithPrefix(t *testing.T) {
+	ws := newWriteSet()
+	ws.set([]byte{0x10, 0x02}, []byte("2"))
+	ws.set([]byte{0x10, 0x01}, []byte("1"))
+	ws.set([]byte{0x11, 0x01}, []byte("other"))
+
+	keys := ws.keysWithPrefix([]byte{0x10})
+	require.Equal(t, [][]byte{
+		{0x10, 0x01},
+		{0x10, 0x02},
+	}, keys)
+}

--- a/node/trx_executor.go
+++ b/node/trx_executor.go
@@ -3,6 +3,7 @@ package node
 import (
 	"fmt"
 
+	"github.com/beatoz/beatoz-go/ctrlers"
 	ctrlertypes "github.com/beatoz/beatoz-go/ctrlers/types"
 	"github.com/beatoz/beatoz-go/types"
 	"github.com/beatoz/beatoz-go/types/bytes"
@@ -25,6 +26,11 @@ func NewTrxExecutor(logger log.Logger) *TrxExecutor {
 
 func (txe *TrxExecutor) ExecuteSync(ctx *ctrlertypes.TrxContext) xerrors.XError {
 	var xerr xerrors.XError
+
+	xerr = reloadTrxAccounts(ctx)
+	if xerr != nil {
+		return xerr
+	}
 
 	xerr = validateTrx(ctx)
 	if xerr != nil {
@@ -111,47 +117,122 @@ func validateTrx(ctx *ctrlertypes.TrxContext) xerrors.XError {
 }
 
 func runTrx(ctx *ctrlertypes.TrxContext) xerrors.XError {
-	var xerr xerrors.XError
-	defer func() {
-		if ctx.Exec || xerr == nil {
-			_xerr0 := postRunTrx(ctx)
-			if xerr != nil {
-				xerr = xerr.Wrap(_xerr0)
-			} else {
-				xerr = _xerr0
+	if ctx.IsHandledByEVM() {
+		return runExecuteTrx(ctx, nil)
+	}
+
+	scope := ctrlers.NewBlockCacheContext(ctx.BlockContext, ctx.Exec)
+	if scope == nil {
+		return xerrors.NewOrdinary("non-EVM transaction cache context is unavailable")
+	}
+	defer scope.Restore(ctx.BlockContext)
+
+	if xerr := reloadTrxAccounts(ctx); xerr != nil {
+		return xerr
+	}
+
+	return runExecuteTrx(ctx, scope)
+}
+
+func runExecuteTrx(ctx *ctrlertypes.TrxContext, cacheScope *ctrlers.BlockCacheContext) xerrors.XError {
+	withCache := cacheScope != nil
+
+	xerr := executeTrx(ctx)
+	if xerr != nil {
+		if withCache {
+			cacheScope.Restore(ctx.BlockContext)
+			if ctx.Exec {
+				if reloadErr := reloadTrxAccounts(ctx); reloadErr != nil {
+					return reloadErr.Wrap(xerr)
+				}
 			}
 		}
-	}()
+		if !ctx.Exec {
+			return xerr
+		}
+		if postErr := postRunTrx(ctx); postErr != nil {
+			return xerr.Wrap(postErr)
+		}
+		return xerr
+	}
 
+	if xerr = reloadTrxAccounts(ctx); xerr != nil {
+		return xerr
+	}
+	if xerr = postRunTrx(ctx); xerr != nil {
+		return xerr
+	}
+	if withCache {
+		return cacheScope.Write()
+	}
+	return nil
+}
+
+func executeTrx(ctx *ctrlertypes.TrxContext) xerrors.XError {
 	switch ctx.Tx.GetType() {
 	case ctrlertypes.TRX_CONTRACT:
-		if xerr = ctx.EVMHandler.ExecuteTrx(ctx); xerr != nil {
+		if xerr := ctx.EVMHandler.ExecuteTrx(ctx); xerr != nil {
 			return xerr
 		}
 	case ctrlertypes.TRX_PROPOSAL, ctrlertypes.TRX_VOTING:
-		if xerr = ctx.GovHandler.ExecuteTrx(ctx); xerr != nil {
+		if xerr := ctx.GovHandler.ExecuteTrx(ctx); xerr != nil {
 			return xerr
 		}
 	case ctrlertypes.TRX_TRANSFER, ctrlertypes.TRX_SETDOC:
 		if ctx.IsHandledByEVM() {
-			if xerr = ctx.EVMHandler.ExecuteTrx(ctx); xerr != nil {
+			if xerr := ctx.EVMHandler.ExecuteTrx(ctx); xerr != nil {
 				return xerr
 			}
-		} else if xerr = ctx.AcctHandler.ExecuteTrx(ctx); xerr != nil {
+		} else if xerr := ctx.AcctHandler.ExecuteTrx(ctx); xerr != nil {
 			return xerr
 		}
 	case ctrlertypes.TRX_WITHDRAW:
-		if xerr = ctx.SupplyHandler.ExecuteTrx(ctx); xerr != nil {
+		if xerr := ctx.SupplyHandler.ExecuteTrx(ctx); xerr != nil {
 			return xerr
 		}
 	case ctrlertypes.TRX_STAKING, ctrlertypes.TRX_UNSTAKING:
-		if xerr = ctx.VPowerHandler.ExecuteTrx(ctx); xerr != nil {
+		if xerr := ctx.VPowerHandler.ExecuteTrx(ctx); xerr != nil {
 			return xerr
 		}
 	default:
 		return xerrors.ErrUnknownTrxType
 	}
 
+	return nil
+}
+
+func reloadTrxAccounts(ctx *ctrlertypes.TrxContext) xerrors.XError {
+	sender := ctx.AcctHandler.FindAccount(ctx.Tx.From, ctx.Exec)
+	if sender == nil {
+		return xerrors.ErrNotFoundAccount.Wrapf("sender address: %v", ctx.Tx.From)
+	}
+
+	toAddr := ctx.Tx.To
+	if toAddr == nil {
+		toAddr = types.ZeroAddress()
+	}
+	receiver := ctx.AcctHandler.FindOrNewAccount(toAddr, ctx.Exec)
+	if receiver == nil {
+		return xerrors.ErrNotFoundAccount.Wrapf("receiver address: %v", toAddr)
+	}
+
+	var payer *ctrlertypes.Account
+	if ctx.Tx.PayerSig != nil {
+		payerAddr, _, xerr := ctrlertypes.VerifyPayerTrxRLP(ctx.Tx)
+		if xerr != nil {
+			return xerr
+		}
+		payer = ctx.AcctHandler.FindAccount(payerAddr, ctx.Exec)
+		if payer == nil {
+			return xerrors.ErrNotFoundAccount.Wrapf("payer address: %v", payerAddr)
+		}
+	} else {
+		payer = sender
+	}
+
+	ctx.Sender = sender
+	ctx.Receiver = receiver
+	ctx.Payer = payer
 	return nil
 }
 

--- a/node/trx_executor_test.go
+++ b/node/trx_executor_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	btzcfg "github.com/beatoz/beatoz-go/cmd/config"
+	"github.com/beatoz/beatoz-go/ctrlers/account"
 	"github.com/beatoz/beatoz-go/ctrlers/mocks"
 	"github.com/beatoz/beatoz-go/ctrlers/mocks/acct"
 	"github.com/beatoz/beatoz-go/ctrlers/mocks/gov"
@@ -16,6 +18,7 @@ import (
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 	abcitypes "github.com/tendermint/tendermint/abci/types"
+	"github.com/tendermint/tendermint/libs/log"
 	tmtypes "github.com/tendermint/tendermint/proto/tendermint/types"
 )
 
@@ -33,6 +36,22 @@ func init() {
 		_ = w.GetAccount().AddBalance(uint256.NewInt(balance))
 		return true
 	})
+}
+
+type failAfterExecuteAcctHandler struct {
+	ctrlertypes.IAccountHandler
+}
+
+func (handler *failAfterExecuteAcctHandler) ExecuteTrx(ctx *ctrlertypes.TrxContext) xerrors.XError {
+	if xerr := handler.IAccountHandler.ExecuteTrx(ctx); xerr != nil {
+		return xerr
+	}
+	return xerrors.ErrInvalidTrx.Wrapf("forced account execute failure")
+}
+
+func (handler *failAfterExecuteAcctHandler) CacheHandlerContext(exec bool) (ctrlertypes.IAccountHandler, func() xerrors.XError) {
+	cached, writeCache := handler.IAccountHandler.(ctrlertypes.ICacheableAccountHandler).CacheHandlerContext(exec)
+	return &failAfterExecuteAcctHandler{IAccountHandler: cached}, writeCache
 }
 
 func Test_commonValidation(t *testing.T) {
@@ -83,6 +102,95 @@ func Test_commonValidation(t *testing.T) {
 	txctx, xerr = mocks.MakeTrxCtxWithTrx(tx, chainId.Hex(), 1, time.Now(), true, govMock, acctMock, nil, nil, nil)
 	require.NoError(t, xerr)
 	require.ErrorContains(t, commonValidation(txctx), xerrors.ErrInsufficientFund.Error())
+}
+
+func TestTxCacheSequence(t *testing.T) {
+	localConfig := btzcfg.DefaultConfig(chainId.Hex())
+	localConfig.SetRoot(t.TempDir())
+
+	acctCtrler, err := account.NewAcctCtrler(localConfig, log.NewNopLogger())
+	require.NoError(t, err)
+	defer func() {
+		if acctCtrler != nil {
+			require.NoError(t, acctCtrler.Close())
+		}
+	}()
+
+	sender := web3.NewWallet(nil)
+	receiver := web3.NewWallet(nil)
+	initialBalance := uint256.NewInt(balance)
+	sender.GetAccount().SetBalance(initialBalance)
+	receiver.GetAccount().SetBalance(uint256.NewInt(0))
+	require.NoError(t, acctCtrler.SetAccount(sender.GetAccount(), true))
+	require.NoError(t, acctCtrler.SetAccount(receiver.GetAccount(), true))
+	_, _, xerr := acctCtrler.Commit()
+	require.NoError(t, xerr)
+
+	bctx := ctrlertypes.TempBlockContext(localConfig.ChainIdHex(), 2, time.Now(), govMock, acctCtrler, nil, nil, nil)
+	txe := NewTrxExecutor(log.NewNopLogger())
+
+	gas := govMock.MinTrxGas()
+	fee := types.GasToFee(gas, govMock.GasPrice())
+	successAmt := uint256.NewInt(1000)
+	rollbackAmt := uint256.NewInt(2000)
+
+	tx1 := web3.NewTrxTransfer(sender.Address(), receiver.Address(), 0, gas, govMock.GasPrice(), successAmt)
+	_, _, err = sender.SignTrxRLP(tx1, localConfig.ChainIdHex())
+	require.NoError(t, err)
+	txctx1, xerr := mocks.MakeTrxCtxWithTrxBctx(tx1, bctx, true)
+	require.NoError(t, xerr)
+
+	tx2 := web3.NewTrxTransfer(sender.Address(), receiver.Address(), 1, gas, govMock.GasPrice(), rollbackAmt)
+	_, _, err = sender.SignTrxRLP(tx2, localConfig.ChainIdHex())
+	require.NoError(t, err)
+	txctx2, xerr := mocks.MakeTrxCtxWithTrxBctx(tx2, bctx, true)
+	require.NoError(t, xerr)
+
+	require.NoError(t, txe.ExecuteSync(txctx1))
+
+	afterTx1Sender := acctCtrler.FindAccount(sender.Address(), true)
+	require.NotNil(t, afterTx1Sender)
+	require.Equal(t, int64(1), afterTx1Sender.GetNonce())
+	require.Equal(t, new(uint256.Int).Sub(initialBalance, new(uint256.Int).Add(successAmt, fee)).Dec(), afterTx1Sender.GetBalance().Dec())
+	afterTx1Receiver := acctCtrler.FindAccount(receiver.Address(), true)
+	require.NotNil(t, afterTx1Receiver)
+	require.Equal(t, successAmt.Dec(), afterTx1Receiver.GetBalance().Dec())
+
+	bctx.AcctHandler = &failAfterExecuteAcctHandler{IAccountHandler: acctCtrler}
+	xerr = txe.ExecuteSync(txctx2)
+	require.Error(t, xerr)
+	require.True(t, xerr.Contains(xerrors.ErrInvalidTrx))
+
+	twoFees := new(uint256.Int).Mul(fee, uint256.NewInt(2))
+	expectedSenderBalance := new(uint256.Int).Sub(initialBalance, new(uint256.Int).Add(successAmt, twoFees))
+	expectedReceiverBalance := successAmt
+
+	afterTx2Sender := acctCtrler.FindAccount(sender.Address(), true)
+	require.NotNil(t, afterTx2Sender)
+	require.Equal(t, int64(2), afterTx2Sender.GetNonce())
+	require.Equal(t, expectedSenderBalance.Dec(), afterTx2Sender.GetBalance().Dec())
+	afterTx2Receiver := acctCtrler.FindAccount(receiver.Address(), true)
+	require.NotNil(t, afterTx2Receiver)
+	require.Equal(t, expectedReceiverBalance.Dec(), afterTx2Receiver.GetBalance().Dec())
+
+	_, _, xerr = acctCtrler.Commit()
+	require.NoError(t, xerr)
+	require.NoError(t, acctCtrler.Close())
+	acctCtrler = nil
+
+	reopened, err := account.NewAcctCtrler(localConfig, log.NewNopLogger())
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, reopened.Close())
+	}()
+
+	committedSender := reopened.FindAccount(sender.Address(), true)
+	require.NotNil(t, committedSender)
+	require.Equal(t, int64(2), committedSender.GetNonce())
+	require.Equal(t, expectedSenderBalance.Dec(), committedSender.GetBalance().Dec())
+	committedReceiver := reopened.FindAccount(receiver.Address(), true)
+	require.NotNil(t, committedReceiver)
+	require.Equal(t, expectedReceiverBalance.Dec(), committedReceiver.GetBalance().Dec())
 }
 
 func Test_Gas_FailedTx(t *testing.T) {

--- a/types/xerrors/xerror.go
+++ b/types/xerrors/xerror.go
@@ -3,8 +3,9 @@ package xerrors
 import (
 	"errors"
 	"fmt"
-	abcitypes "github.com/tendermint/tendermint/abci/types"
 	"strings"
+
+	abcitypes "github.com/tendermint/tendermint/abci/types"
 )
 
 const (
@@ -82,6 +83,7 @@ var (
 	ErrDuplicatedKey         = NewOrdinary("already existed key")
 	ErrInvalidWeight         = NewOrdinary("invalid weight")
 	ErrBlockHashLookup       = NewOrdinary("failed to lookup block hash")
+	ErrInvalidLedgerKey      = NewOrdinary("invalid ledger key")
 )
 
 type XError interface {


### PR DESCRIPTION
# BG-595 Cache Write 코드 리뷰 가이드

## 목적

BG-595는 non-EVM transaction 실행 중 실패한 transaction의 partial write가 block state에 남을 수 있는 문제를 해결한다.

기존 구조에서는 controller가 `ExecuteTrx()` 도중 mutable ledger의 `Set()` 또는 `Del()`을 호출하면 변경사항이 IAVL mutable tree에 즉시 반영될 수 있었다. 그 뒤 같은 transaction 안에서 다른 작업이 실패해도, 앞서 반영된 controller state가 block state에 남는 문제가 발생할 수 있었다.

이번 변경의 핵심은 transaction 성공이 확정되기 전까지 IAVL tree를 변경하지 않는 것이다. non-EVM transaction write는 먼저 transaction-local cache에 기록되고, `ExecuteTrx()`와 `postRunTrx()`가 모두 성공한 뒤에만 parent cache로 승격된다.

기존 failed DeliverTx 정책은 유지한다.

- 실패한 transaction의 module write는 tx cache에만 남고 parent block cache나 IAVL로 승격되지 않는다.
- 실패한 DeliverTx의 fee/nonce 변경은 유지된다.
- 성공한 transaction state는 같은 block의 다음 transaction에서 읽을 수 있다.
- block commit 시점에만 block-level pending write가 IAVL에 flush된다.

## 큰 구조

이번 변경은 새 ledger 구현 package를 추가한다.

```text
ledger/v2
```

`ledger/v1`은 그대로 유지한다. BG-595 대상 non-EVM controller들은 `ledger/v2`를 사용하도록 변경한다.

새 write 구조는 다음과 같다.

```text
IAVL tree
  ^
  | block commit 시 flush
  |
block cache
  ^
  | 성공한 transaction의 Write()
  |
tx cache
```

실패 처리는 별도 복구 API를 호출하는 방식이 아니다. child cache의 `Write()`를 호출하지 않고 버리는 방식으로 표현한다.

```text
tx success -> tx cache Write()
tx failure -> tx cache discard
block commit -> block cache Write() -> IAVL SaveVersion()
```

이 구조는 snapshot/revert 방식보다 Cosmos SDK cache-store 방식에 가깝다. `ledger/v2`에는 `BeginTx()`, `CommitTx()`, `RollbackTx()`, `Snapshot()`, `RevertToSnapshot()` 흐름을 만들지 않는다.

## 주요 코드 영역

### `ledger/v2`

`ledger/v2`는 cache-write 방식의 ledger 구현이다.

주요 파일은 다음과 같다.

```text
ledger/v2/types.go
ledger/v2/write_set.go
ledger/v2/cache_context.go
ledger/v2/mem_ledger.go
ledger/v2/mutable_ledger.go
ledger/v2/state_ledger.go
```

`types.go`는 V2 interface를 정의한다. 핵심 추가점은 `IStateLedger.CacheContext(bool)`이다.

```go
CacheContext(bool) (IStateLedger, func() xerrors.XError)
```

이 함수는 cached state ledger와 write closure를 반환한다. 호출자는 transaction 실행 동안 cached ledger를 사용하고, transaction을 parent cache에 반영해야 할 때만 write closure를 호출한다.

또한 `types.go`에는 unknown key prefix를 error path로 전달하기 위한 `invalidLedgerItem` helper가 포함되어 있다. 이 helper는 `xerrors.ErrInvalidLedgerKey`를 wrap한 error를 encode/decode 시 반환한다.

`write_set.go`는 key별 마지막 write operation만 저장한다. key/value byte slice는 복사해서 보관하므로, caller가 입력 slice를 이후에 수정해도 cache 내부 값은 변하지 않는다.

`cache_context.go`는 공통 cache primitive다. 다음 동작을 담당한다.

- local `Set` 기록
- local `Delete` marker 기록
- parent cache/tree read-through
- nested `CacheWrap()`
- deterministic `Write()` order
- `Seek`/`Iterate` overlay 처리를 위한 prefix key lookup
- nil parent 방어

`mutable_ledger.go`의 핵심 변경은 `Set()`/`Del()`이 IAVL을 직접 변경하지 않는다는 점이다.

- `Set()`은 item을 encode한 뒤 cache write만 기록한다.
- `Del()`은 cache delete marker만 기록한다.
- 두 함수 모두 IAVL mutable tree를 직접 mutate하지 않는다.
- `Commit()`에서 block cache를 IAVL로 flush한 뒤 `SaveVersion()`을 호출한다.
- commit 이후에는 committed tree 위에 fresh block cache를 다시 만든다.

`mem_ledger.go`도 `mutable_ledger.go`와 같은 cache context 구조를 사용한다. 따라서 check/simulation path와 execution path가 서로 다른 실패 처리 모델을 갖지 않는다.

`state_ledger.go`는 mutable ledger와 mem ledger를 연결한다.

- `exec == true`이면 mutable/block ledger path를 감싼다.
- `exec == false`이면 mem ledger path를 감싼다.
- 반환된 write closure는 선택된 child cache만 parent로 승격한다.

### Controllers

non-EVM controller들은 `ledger/v2`를 import하도록 변경됐다.

```text
ctrlers/account
ctrlers/gov
ctrlers/supply
ctrlers/vpower
```

각 controller는 typed cache context method를 제공한다.

```go
func (ctrler *AcctCtrler) CacheContext(exec bool) (*AcctCtrler, func() xerrors.XError)
func (ctrler *GovCtrler) CacheContext(exec bool) (*GovCtrler, func() xerrors.XError)
func (ctrler *SupplyCtrler) CacheContext(exec bool) (*SupplyCtrler, func() xerrors.XError)
func (ctrler *VPowerCtrler) CacheContext(exec bool) (*VPowerCtrler, func() xerrors.XError)
```

handler interface를 통해 사용할 수 있도록 `CacheHandlerContext()`도 추가했다.

`CacheHandlerContext()`는 base handler interface에 직접 포함하지 않고 optional capability interface로 분리한다.

```go
type ICacheableAccountHandler interface {
    IAccountHandler
    CacheHandlerContext(bool) (IAccountHandler, func() xerrors.XError)
}
```

동일한 패턴으로 `ICacheableGovHandler`, `ICacheableSupplyHandler`, `ICacheableVPowerHandler`가 있다. `ctrlers/cache_context.go`는 익명 interface assertion 대신 이 명시 인터페이스들을 사용한다. 이 구조는 handler의 도메인 기능과 cache orchestration 기능을 분리하면서, cacheable handler라는 의도를 코드에 드러낸다.

controller cache method는 복구 작업을 직접 수행하지 않는다. cached state ledger를 가진 새 controller를 만들고 write closure를 반환한다. transaction이 실패하면 cached controller를 버리면 된다.

controller 내부의 mutable in-memory state는 필요한 경우 복사한다.

- account의 pending/new account map은 clone한다.
- vpower의 delegatee/limiter state는 transaction-local mutation이 parent controller로 새지 않도록 복사한다.

unknown key prefix panic 제거는 다음 파일에 반영됐다.

```text
ctrlers/gov/ctrler.go
ctrlers/supply/ctrler.go
ctrlers/vpower/ctrler.go
```

기존에는 알 수 없는 prefix에서 panic이 날 수 있었지만, 이제는 `ledger/v2.NewInvalidLedgerItem(...)`을 반환해서 encode/decode error로 연결한다.
이 error는 `xerrors.ErrInvalidLedgerKey`를 포함한다.

### `ctrlers/cache_context.go`

`ctrlers.NewBlockCacheContext()`는 cache 가능한 non-EVM handler들을 하나의 transaction scope로 감싼다.

이 함수는 `BlockContext`의 다음 handler들을 임시로 cached handler로 교체한다.

```text
GovHandler
AcctHandler
SupplyHandler
VPowerHandler
```

scope는 원래 handler를 보관하고, `Restore()`로 복구한다. transaction이 성공하면 `Write()`가 각 controller의 write closure를 호출한다.

이 구조 덕분에 `node.TrxExecutor`는 controller 내부 ledger field를 알 필요가 없다. executor는 block-level cache scope만 생성하고, 성공 시 `Write()`, 실패 시 `Restore()`만 호출한다.

필수 non-EVM handler가 `ICacheable*Handler`를 구현하지 못하면 `NewBlockCacheContext()`는 nil을 반환한다. 이 경우 transaction 실행은 다음 error로 실패한다.

```text
non-EVM transaction cache context is unavailable
```

nil handler는 no-op cache participant로 처리한다. 테스트나 일부 handler만 있는 partial block context에서 불필요한 실패를 막기 위한 처리다.

### `node/trx_executor.go`

`runTrx()`는 EVM transaction과 non-EVM transaction을 먼저 분리한 뒤, execute 이후 후처리는 `runExecuteTrx(ctx, cacheScope)`에서 공통 처리한다.

EVM transaction은 `cacheScope == nil`로 실행한다. 기존 EVM rollback 구조를 유지하고, EVM `StateDBWrapper` 동작을 ledger V2 cache semantics와 섞지 않기 위해서다.

non-EVM transaction은 새 cache scope를 사용한다.

```text
runTrx(ctx)
  -> if EVM:
       runExecuteTrx(ctx, nil)

  -> if non-EVM:
       scope := NewBlockCacheContext(ctx.BlockContext, ctx.Exec)
       reloadTrxAccounts(ctx)
       runExecuteTrx(ctx, scope)

runExecuteTrx(ctx, cacheScope)
  -> executeTrx(ctx)

  -> success:
       reloadTrxAccounts(ctx)
       postRunTrx(ctx)
       if cacheScope != nil:
           cacheScope.Write()
       return nil

  -> failure:
       if cacheScope != nil:
           cacheScope.Restore(ctx.BlockContext)
           if ctx.Exec:
               reloadTrxAccounts(ctx)
       if ctx.Exec:
           postRunTrx(ctx)
       return original error
```

success path에서 중요한 점은 `cacheScope.Write()`가 `ExecuteTrx()`와 `postRunTrx()`가 모두 성공한 뒤에만 호출된다는 것이다. `ExecuteTrx()`가 성공해도 `postRunTrx()`가 실패하면 transaction cache는 parent로 승격되지 않는다.

failure path에서 중요한 점은 failed DeliverTx fee/nonce 처리 전에 cached controller scope를 먼저 restore한다는 것이다. 이 순서 때문에 실패한 `ExecuteTrx()`의 module write는 버려지고, `postRunTrx()`의 fee/nonce write만 parent block cache에 남는다.

EVM failure path는 `cacheScope == nil`이므로 account reload를 하지 않는다. EVM state는 `StateDBWrapper` snapshot/revert 흐름으로 되돌리고, failed DeliverTx에서는 기존 policy대로 `postRunTrx()`로 fee/nonce만 반영한다.

`reloadTrxAccounts()`는 다음 pointer를 ledger에서 다시 읽어 갱신한다.

```text
ctx.Sender
ctx.Receiver
ctx.Payer
```

이 처리가 필요한 이유는 `TrxContext`가 같은 block의 이전 transaction 실행 전에 준비될 수 있기 때문이다. 또한 cache discard 이후 stale Go object pointer가 parent state를 덮어쓰는 것도 방지한다.

## Transaction State 예시

### Failed withdraw cache discard

BG-595의 대표 문제는 다음 흐름이다.

```text
SupplyCtrler.withdrawReward()
  -> reward state 변경
  -> 이후 account reward 작업 실패
  -> transaction error 반환
```

V2에서는 다음처럼 처리된다.

```text
reward mutation -> tx cache
account reward 실패
tx cache discard
failed DeliverTx postRunTrx가 fee/nonce를 parent block cache에 반영
```

reward mutation은 parent block cache나 IAVL에 남지 않는다.

### 성공한 tx 이후 다음 tx

같은 block에서 두 transaction이 실행되는 경우:

```text
tx1 success -> tx1 cache Write() -> parent block cache
tx2 reloadTrxAccounts()가 parent block cache를 읽음
tx2는 tx1이 반영한 nonce/balance 기준으로 validate/execute
```

이 때문에 cache는 tx별로 완전히 고립된 구조가 아니라 parent/child 계층 구조를 갖는다.

### partial account transfer 후 실패

account transfer state가 변경된 뒤 handler가 error를 반환하는 경우:

```text
transfer state -> tx cache
handler error
tx cache discard
postRunTrx fee/nonce -> parent block cache
```

최종적으로 fee/nonce 정책만 남고 transfer state는 parent state에 반영되지 않는다.

## Panic 및 경계값 방어

마지막 hardening 작업에서는 이번 변경으로 노출될 수 있는 panic 지점을 error path로 바꿨다.

- ledger V2 public method는 nil item, nil callback, closed ledger를 방어한다.
- nil parent를 가진 cache context는 panic 대신 error를 반환한다.
- controller `newItemFor` unknown-key case는 panic 대신 invalid ledger item을 반환한다.
- vpower decode는 address byte slicing 전에 ledger key length를 검증한다.

정상 key path의 동작은 바꾸지 않되, malformed data나 unexpected key prefix가 process panic으로 이어지지 않도록 만든 변경이다.