### PR TITLE
fix: Fix version tag detection logic in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ ifdef MAKECMDGOALS
 	endif
 endif
 
-VERTAG ?= $(shell git tag --sort=-v:refname | grep '^v[0-9]' | head -n1)
+VERTAG ?= $(shell git describe --tags --abbrev=0 --match 'v[0-9]*' 2>/dev/null)
 GITCOMMIT ?= $(shell git log -1 --pretty=format:"%h")
 BUILD_FLAGS=-a -ldflags "-w -s -X 'github.com/beatoz/beatoz-go/cmd/version.GitCommit=$(GITCOMMIT)' -X 'github.com/beatoz/beatoz-go/cmd/version.Version=$(VERTAG)'"
 


### PR DESCRIPTION
## Summary

Fixes an issue where `beatoz version` reported the highest version tag in the entire repository, regardless of the commit actually being built.

## Problem

`VERTAG` in the `Makefile` picked the **highest tag across the whole repo**, so resetting to a past commit — or building `main` HEAD — still stamped the newest tag (e.g. an rc tag from `develop`) as the version.

```makefile
VERTAG ?= $(shell git tag --sort=-v:refname | grep '^v[0-9]' | head -n1)
```

As a result, building `main` could report a version different from the released one once a later `develop` push created a new rc tag.

## Fix

Use `git describe` so only the most recent tag **reachable from the current HEAD (an ancestor)** is selected.

```makefile
VERTAG ?= $(shell git describe --tags --abbrev=0 --match 'v[0-9]*' 2>/dev/null)
```

## Notes

- `main` builds are no longer affected by rc tags on `develop`; they report the correct release version.
- Merging triggers `release.yml`, which creates the `v2.0.1` release automatically.
- For an accurate local build, run `git fetch --tags origin` beforehand (versioning is tag-based).

🤖 Generated with [Claude Code](https://claude.com/claude-code)