### PR TITLE
Set fork block height and fix version tag detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ ifdef MAKECMDGOALS
 	endif
 endif
 
-VERTAG ?= $(shell git tag --sort=-v:refname | grep '^v[0-9]' | head -n1)
+VERTAG ?= $(shell git describe --tags --abbrev=0 --match 'v[0-9]*' 2>/dev/null)
 GITCOMMIT ?= $(shell git log -1 --pretty=format:"%h")
 BUILD_FLAGS=-a -ldflags "-w -s -X 'github.com/beatoz/beatoz-go/cmd/version.GitCommit=$(GITCOMMIT)' -X 'github.com/beatoz/beatoz-go/cmd/version.Version=$(VERTAG)'"
 

--- a/types/params.go
+++ b/types/params.go
@@ -10,8 +10,8 @@ var (
 		// all forks are enabled
 	}
 	testnetForkBlocks = ForkBlocks{
-		BTIP27Block: 100_000,
-		BTIP35Block: 100_000,
+		BTIP27Block: 194_850,
+		BTIP35Block: 194_850,
 	}
 
 	mainnetForkBlocks = ForkBlocks{

--- a/types/params_test.go
+++ b/types/params_test.go
@@ -12,6 +12,6 @@ func Test_ForkBlocks(t *testing.T) {
 
 	require.False(t, IsBTIP27(chainId.Hex(), 0))
 	require.False(t, IsBTIP27(chainId.Hex(), 100))
-	require.True(t, IsBTIP27(chainId.Hex(), 100_000))
-	require.True(t, IsBTIP27(chainId.Hex(), 1_000_000))
+	require.True(t, IsBTIP27(chainId.Hex(), 194_850))
+	require.True(t, IsBTIP27(chainId.Hex(), 200_000))
 }


### PR DESCRIPTION
### Summary

This pull request includes the following changes:

- Added block height settings for BTIP27 and BTIP35 forks.
- Resolved an issue with version tag detection logic in the Makefile.

### Checklist

- [x] Unit tests added/updated
- [x] Documentation updated (if applicable)
- [x] Code reviewed and approved